### PR TITLE
Add a 'q' parameter for filtering tile data

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+	"filterQueryArgumentName": "q",
+	"selectAllFieldsSql": "SELECT * FROM treemap_plot LEFT JOIN treemap_tree ON treemap_plot.id = treemap_tree.plot_id LEFT JOIN treemap_species ON treemap_tree.species_id = treemap_species.id"
+}


### PR DESCRIPTION
The q parameter is converted from OTM2 JSON to a SQL
select statement that is compatible with windshaft/grainstore.

I pushed hardcoded values out to config.json so they can be easily changed
or replaced via templating during deployment.
