### PR TITLE
Throw when attempting to convert empty filter to sql

### DIFF
--- a/filterStringToSql.js
+++ b/filterStringToSql.js
@@ -22,7 +22,9 @@ var moment = require('moment');
 // string.
 
 exports = module.exports = function (s) {
-    if (!s) { return ''; }
+    if (!s) {
+        throw new Error('A null, undefined, or empty filter string cannot be converted to SQL');
+    }
     return filterToSql(JSON.parse(s));
 };
 
@@ -224,6 +226,9 @@ function fieldNameAndPredicateToSql(fieldName, predicate) {
 // `objectToSql` converts a filter object to a valid SQL WHERE clause.
 function objectToSql(o) {
     var statements = [];
+    if (Object.keys(o).length === 0) {
+        throw new Error("An empty object cannot be converted to SQL");
+    }
     _.each(o, function (valueOrPredicate, fieldName) {
         var predicate;
         if (!_.isObject(valueOrPredicate)) {

--- a/server.js
+++ b/server.js
@@ -32,12 +32,10 @@ var windshaftConfig = {
     enable_cors: true,
     postgres: { password: 'otm', user: 'otm' },
     req2params: function(req, callback){
-
-        if (req.query[config.filterQueryArgumentName]) {
+        var filterString = req.query[config.filterQueryArgumentName];
+        if (filterString) {
             try {
-                req.query.sql = filterStringToGrainstoreSqlQuery(
-                    req.query[config.filterQueryArgumentName]
-                );
+                req.query.sql = filterStringToGrainstoreSqlQuery(filterString);
             } catch (err) {
                 callback(err, null);
             }

--- a/test/testFilterStringToSql.js
+++ b/test/testFilterStringToSql.js
@@ -11,15 +11,21 @@ describe('filterStringToSql', function() {
     // NULL AND EMPTY HANDLING
 
     it('returns an empty string when passed undefined', function() {
-        assertSql(undefined, '');
+        assert.throws(function() {
+            filterStringToSql(undefined);
+        }, Error);
     });
 
     it('returns an empty string when passed null', function() {
-        assertSql(null, '');
+        assert.throws(function() {
+            filterStringToSql(null);
+        }, Error);
     });
 
     it('returns an empty string when passed an empty string', function() {
-        assertSql('', '');
+        assert.throws(function() {
+            filterStringToSql('');
+        }, Error);
     });
 
     // INVALID JSON HANDLING


### PR DESCRIPTION
The previous behavior of returning an empty string was causing downstream
problems because the sql being generated is actually a WHERE clause, and an
empty WHERE clause is invalid.
