### PR TITLE
Add in boundary zone filter and additional predicate syntax

### DIFF
--- a/test/testFilterStringToSql.js
+++ b/test/testFilterStringToSql.js
@@ -102,6 +102,16 @@ describe('filterStringToSql', function() {
         }, Error);
     });
 
+    // IN_BOUNDARY matches
+
+    if ('returns a ST_Contains function', function() {
+        assertSql('{"plot.geom": {"IN_BOUNDARY": 6}}',
+                  "(ST_Contains(" +
+                    "(SELECT the_geom_webmercator " +
+                    "FROM treemap_boundary WHERE id=6), " +
+                  "treemap_plot.the_geom_webmercator))");
+    });
+
     // MIN AND MAX MATCHES
 
     it('return a less or equal to clause', function () {


### PR DESCRIPTION
Previously the tiler support the simple concept of an infix binary
operator for SQL by making the following assumptions:
- The left hand side was always the column name
- The operator/matcher is the infix op and is appended to the LHS
- The right hand side was a function that converts a single value in the
  predicate to a single SQL literal for the RHS

When developing the boundary filter query to goal is to actually call a
function similar to:

``` sql
ST_Contains(polygon, the_column_to_test)
```

Which doesn't fit the mold the matcher/value mold. The solution is to
break up the abstraction by providing a generic transformation object,
`predicateTransform`, in the predicates list.

That function can return a 'literal' value which is an underscore
template that will be evaluated with a single value, the column name to
render (called 'column')
