### PR TITLE
Filter by instance id for plots and boundaries

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,9 +1,11 @@
 {
     "filterQueryArgumentName": "q",
+    "defaultSelectSql": "SELECT * FROM treemap_plot",
     "selectAllFieldsSql": {
         "plot": "SELECT * FROM treemap_plot LEFT JOIN treemap_tree ON treemap_plot.id = treemap_tree.plot_id LEFT JOIN treemap_species ON treemap_tree.species_id = treemap_species.id",
         "tree": "SELECT * FROM treemap_plot JOIN treemap_tree ON treemap_plot.id = treemap_tree.plot_id JOIN treemap_species ON treemap_tree.species_id = treemap_species.id"
     },
+    "boundarySql": "(SELECT the_geom_webmercator FROM treemap_boundary JOIN treemap_instance_boundaries ON treemap_instance_boundaries.boundary_id = treemap_boundary.id WHERE treemap_instance_boundaries.instance_id=<%= instanceid %>) otmfiltersql",
     "customDbFieldNames": {
         "geom": "the_geom_webmercator"
     }


### PR DESCRIPTION
Both plot and boundary tiles require an instance to render the proper
subset of their respective elements. However, the method for generating
the SQL requires two different approaches.

Since we're only using one route we can just switch on the table name.
