### PR TITLE
Specify a windshaft SHA in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/azavea/OTM2-tiler"
     },
     "dependencies": {
-        "windshaft": "git+https://github.com/azavea/Windshaft#master",
+        "windshaft": "git+https://github.com/azavea/Windshaft#5d69613d",
         "underscore": "~1.3",
         "semver": "~1.1.0",
         "moment": "~2.1.0"


### PR DESCRIPTION
The specified SHA is version 0.13.1

This allows us to update the master branch of our fork of Windshaft
without automatically triggering an update to the tiler.
