### PR TITLE
Add support for filtering on udfs

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
     "filterQueryArgumentName": "q",
+    "scalar_udf_field": "udf_scalar_values",
     "sqlForPlots": {
         "fields": {
             "base": "the_geom_webmercator",

--- a/test/testFilterStringToWhere.js
+++ b/test/testFilterStringToWhere.js
@@ -97,6 +97,13 @@ describe('filterStringToWhere', function() {
                   "(\"treemap_plot\".\"address\" ILIKE '%Market St%')");
     });
 
+    // UDF MATCHES
+    it('processes udf values', function() {
+        assertSql('{"plot.udf:Clever Name": {"LIKE": "%Market St%"}}',
+                  "(\"treemap_plot\".\"udf_scalar_values\"->'Clever Name' " +
+                  "ILIKE '%Market St%')");
+    });
+
     // LIST MATCHES
 
     it('returns an IN clause for a numeric list', function () {


### PR DESCRIPTION
Filtering on string udfs is now support using the following syntax:

```
{'plot.udf:Nickname': ...}
```

The main goal is to intercept udf field names and transform:

```
plot.udf:Nickname -> "treemap_plot"."udf_scalar_values"->'Nickname'
```
