### PR TITLE
Support ISNULL predicate

### DIFF
--- a/filterStringToWhere.js
+++ b/filterStringToWhere.js
@@ -12,6 +12,7 @@
 //                    | 'EXCLUSIVE'
 //                    | 'IN'
 //                    | 'IS'
+//                    | 'ISNULL'
 //                    | 'LIKE'
 //                    | 'WITHIN_RADIUS'
 //                    | 'IN_BOUNDARY'
@@ -48,6 +49,11 @@ var PREDICATE_TYPES = {
         combinesWith: [],
         matcher: '=',
         valueConverter: convertValueToEscapedSqlLiteral
+    },
+    ISNULL: {
+        combinesWith: [],
+        matcher: 'IS',
+        valueConverter: convertValueForIsNull,
     },
     IN: {
         combinesWith: [],
@@ -209,6 +215,12 @@ function convertArrayValueToEscapedSqlLiteral(arrayValue) {
 // into the correct Postgres literal.
 function convertValuesToEscapedSqlLiterals(values) {
     return _.map(values, convertValueToEscapedSqlLiteral);
+}
+
+// `convertValueForIsNull` converts a literal to "NULL" or "NOT NULL" based on its
+// truthiness.  Truthy values -> "NULL", falsey values -> "NOT NULL"
+function convertValueForIsNull(value) {
+    return !!value ? "NULL" : "NOT NULL";
 }
 
 // `validatePredicate` throws an error if the specified `predicate` object

--- a/test/testFilterStringToWhere.js
+++ b/test/testFilterStringToWhere.js
@@ -121,6 +121,15 @@ describe('filterStringToWhere', function() {
         }, Error);
     });
 
+    // ISNULL MATCHES
+    it('returns IS NULL for true', function() {
+        assertSql('{"species.id": {"ISNULL": true}}', '("treemap_species"."id" IS NULL)');
+    });
+
+    it('returns IS NOT NULL for false', function() {
+        assertSql('{"species.id": {"ISNULL": false}}', '("treemap_species"."id" IS NOT NULL)');
+    });
+
     // IN_BOUNDARY MATCHES
 
     if ('returns a ST_Contains function', function() {


### PR DESCRIPTION
Makes implementing filters for missing data or has/doesn't have a tree
easier to implement
