### PR TITLE
Change mapFeature->plot in udfc query syntax

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,7 +29,7 @@
                 "depends": ["mapFeature", "tree"],
                 "sqlTemplate": "LEFT OUTER JOIN treemap_userdefinedcollectionvalue ON (treemap_tree.id = treemap_userdefinedcollectionvalue.model_id AND treemap_userdefinedcollectionvalue.field_definition_id = <%= udfFieldDefId %>)"
             },
-            "udf:mapFeature": {
+            "udf:plot": {
                 "depends": ["mapFeature"],
                 "sqlTemplate": "LEFT OUTER JOIN treemap_userdefinedcollectionvalue ON (treemap_mapfeature.id = treemap_userdefinedcollectionvalue.model_id AND treemap_userdefinedcollectionvalue.field_definition_id = <%= udfFieldDefId %>)"
             }
@@ -51,6 +51,6 @@
         "species": "treemap_species",
         "treePhoto": "treemap_treephoto",
         "udf:tree": "treemap_userdefinedcollectionvalue",
-        "udf:mapFeature": "treemap_userdefinedcollectionvalue"
+        "udf:plot": "treemap_userdefinedcollectionvalue"
     }
 }

--- a/test/testFilterObjectToWhere.js
+++ b/test/testFilterObjectToWhere.js
@@ -292,7 +292,7 @@ describe('filterObjectToWhere', function() {
     });
 
     it('converts hstore date fields from string to postgres date without timezone', function () {
-        assertSql({"udf:mapFeature:19.Date": {"MIN": "2014-03-02 00:00:00"}},
+        assertSql({"udf:plot:19.Date": {"MIN": "2014-03-02 00:00:00"}},
                   "(to_date(\"treemap_userdefinedcollectionvalue\".\"data\"->'Date'::text, 'YYYY-MM-DD') " +
                   ">= (DATE '2014-03-02' + TIME '00:00:00'))");
     });

--- a/test/testFilterObjectUtils.js
+++ b/test/testFilterObjectUtils.js
@@ -17,17 +17,17 @@ describe('testGetUdfFieldDefId', function() {
     });
     it('returns the correct udfd id for udfc queries', function() {
         assert.equal(18,
-                     udfForJSON('{"udf:mapFeature:18.Action":"Watered", ' + 
-                                '"udf:mapFeature:18.Date":"2014-03-31"}'));
+                     udfForJSON('{"udf:plot:18.Action":"Watered", ' +
+                                '"udf:plot:18.Date":"2014-03-31"}'));
     });
     it('raises when multiple udfd ids are present', function() {
         assert.throws(udfForJSON,
-                      '{"udf:mapFeature:18.Action":"Watered", ' +
-                      '"udf:mapFeature:19.Action":"Watered"}');
+                      '{"udf:plot:18.Action":"Watered", ' +
+                      '"udf:plot:19.Action":"Watered"}');
     });
     it('returns the correct udfd id for multi-predicate queries', function() {
-        assert.equal(18, udfForJSON('{"udf:mapFeature:18.Action":"Watered", ' + 
-                                    '"udf:mapFeature:18.Date":"2014-03-31",' + 
+        assert.equal(18, udfForJSON('{"udf:plot:18.Action":"Watered", ' +
+                                    '"udf:plot:18.Date":"2014-03-31",' +
                                     ' "tree.diameter": 15}'));
     });
 });
@@ -35,8 +35,8 @@ describe('testGetUdfFieldDefId', function() {
 
 describe('testParseUdfCollectionFieldName', function() {
     it('returns the correct parsed object for udfc keys', function () {
-        var results = utils.parseUdfCollectionFieldName('udf:mapFeature:18.Action');
-        assert.equal(results.modelName, 'udf:mapFeature');
+        var results = utils.parseUdfCollectionFieldName('udf:plot:18.Action');
+        assert.equal(results.modelName, 'udf:plot');
         assert.equal(results.fieldDefId, '18');
         assert.equal(results.hStoreMember, 'Action');
     });

--- a/test/testFiltersToTables.js
+++ b/test/testFiltersToTables.js
@@ -84,7 +84,7 @@ describe('filtersToTables', function() {
     });
 
     it('returns udfd/udcv and joins for udf mapfeature filter objects', function () {
-        var sql = filtersToTables({"udf:mapFeature:18.Action": {"LIKE": "%Watering%"}}, undefined);
+        var sql = filtersToTables({"udf:plot:18.Action": {"LIKE": "%Watering%"}}, undefined);
         var expectedSql =
                 "treemap_mapfeature LEFT OUTER JOIN treemap_userdefinedcollectionvalue " +
                 "ON (treemap_mapfeature.id = treemap_userdefinedcollectionvalue.model_id AND " +


### PR DESCRIPTION
This was primarily done to make the django portions, client and server, more flexible. UDFCs are handled generically on the tiler, but the side sending the request is specific to plot, so it makes sense to send the query as "udf:plot" instead of "udf:mapFeature". If we start adding support for UDFCs on other mapFeatures, we need only add another rule to this config.
