### PR TITLE
Update to version 19.4 of windshaft

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/azavea/OTM2-tiler"
     },
     "dependencies": {
-        "windshaft": "0.13.7",
+        "windshaft": "0.19.4",
         "underscore": "~1.3",
         "semver": "~1.1.0",
         "moment": "~2.1.0"


### PR DESCRIPTION
... to resolve "npm install" issues. There's a version 20.0, but 19.4 seems a safer bet.
