### PR TITLE
Add support for querying multiple UDF collections at once.

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,13 +26,17 @@
                 "depends": ["mapFeature"],
                 "sql": "LEFT OUTER JOIN treemap_mapfeaturephoto ON treemap_mapfeature.id = treemap_mapfeaturephoto.map_feature_id"
             },
+            "udf": {
+                "depends": [],
+                "sql": "CROSS JOIN treemap_userdefinedcollectionvalue"
+            },
             "udf:tree": {
-                "depends": ["mapFeature", "tree"],
-                "sqlTemplate": "LEFT OUTER JOIN treemap_userdefinedcollectionvalue ON (treemap_tree.id = treemap_userdefinedcollectionvalue.model_id AND treemap_userdefinedcollectionvalue.field_definition_id = <%= udfFieldDefId %>)"
+                "depends": ["mapFeature", "tree", "udf"],
+                "sql": ""
             },
             "udf:plot": {
-                "depends": ["mapFeature"],
-                "sqlTemplate": "LEFT OUTER JOIN treemap_userdefinedcollectionvalue ON (treemap_mapfeature.id = treemap_userdefinedcollectionvalue.model_id AND treemap_userdefinedcollectionvalue.field_definition_id = <%= udfFieldDefId %>)"
+                "depends": ["mapFeature", "udf"],
+                "sql": ""
             }
         },
         "where": {
@@ -53,6 +57,10 @@
         "mapFeaturePhoto": "treemap_mapfeaturephoto",
         "udf:tree": "treemap_userdefinedcollectionvalue",
         "udf:plot": "treemap_userdefinedcollectionvalue"
+    },
+    "udfcTemplates": {
+        "udf:tree": "treemap_userdefinedcollectionvalue.field_definition_id=<%= fieldDefId %> AND treemap_userdefinedcollectionvalue.model_id=treemap_tree.id",
+        "udf:plot": "treemap_userdefinedcollectionvalue.field_definition_id=<%= fieldDefId %> AND treemap_userdefinedcollectionvalue.model_id=treemap_mapfeature.id"
     },
     "treeMarkerMaxWidth": 20
 }

--- a/filterObjectUtils.js
+++ b/filterObjectUtils.js
@@ -94,26 +94,6 @@ function parseUdfCollectionFieldName (fieldName) {
     };
 }
 
-// `getUdfFieldDefId` examines a filterObject to determine if it has
-// predicates for `(python)UserDefinedCollectionValues`. This is
-// necessary for adding an additional component to the where clause to
-// filter on the `(python)UserDefinedFieldDefinition` id.  When ids
-// are found, they are validated not to allow multiple ids, which are
-// not supported.  returns null for non UDCV queries.
-function getUdfFieldDefId (filterObject) {
-    var udfCollectionValues = _.reject(_(_.keys(filterObject)).map(parseUdfCollectionFieldName), _.isNull),
-        udfFieldDefIds = _.uniq(_.pluck(udfCollectionValues, 'fieldDefId'));
-    if (udfFieldDefIds.length === 1) {
-        return udfFieldDefIds[0];
-    } else if (udfFieldDefIds.length === 0) {
-        return null;
-    } else {
-        throw ("Multiple UserDefinedFieldDefinition ids found in filterObject. " +
-               "Only one is supported per request.");
-    }
-}
-
-
 module.exports = {
     traverseCombinator: traverseCombinator,
 
@@ -124,8 +104,6 @@ module.exports = {
     sanitizeSqlString: sanitizeSqlString,
 
     parseUdfCollectionFieldName: parseUdfCollectionFieldName,
-
-    getUdfFieldDefId: getUdfFieldDefId,
 
     DATETIME_FORMATS: DATETIME_FORMATS
 };

--- a/filtersToTables.js
+++ b/filtersToTables.js
@@ -15,10 +15,10 @@ exports = module.exports = function (filterObject, displayFilters) {
     if (models.length === 0) {
         models = [config.sqlForMapFeatures.baseTable];
     }
-    return getSqlForModels(models, utils.getUdfFieldDefId(filterObject));
+    return getSqlForModels(models);
 };
 
-function getSqlForModels(models, maybeUdfFieldDefId) {
+function getSqlForModels(models) {
     var sql = [];
     var modelsAdded = [];
 
@@ -33,8 +33,6 @@ function getSqlForModels(models, maybeUdfFieldDefId) {
             var template = config.sqlForMapFeatures.tables[model].sqlTemplate;
             if (_.isUndefined(template)) {
                 sql.push(config.sqlForMapFeatures.tables[model].sql);
-            } else {
-                sql.push(_.template(template)({udfFieldDefId: maybeUdfFieldDefId}));
             }
 
             modelsAdded.push(model);

--- a/test/testFilterObjectUtils.js
+++ b/test/testFilterObjectUtils.js
@@ -7,32 +7,6 @@ function udfForJSON (json) {
     return utils.getUdfFieldDefId(JSON.parse(json));
 }
 
-describe('testGetUdfFieldDefId', function() {
-
-    it('returns null for empty filterObject', function() {
-        assert.equal(udfForJSON('{}'), null);
-    });
-    it('returns null for non udfc queries', function() {
-        assert.equal(udfForJSON('{"tree.diameter": {"IS": 11}}'), null);
-    });
-    it('returns the correct udfd id for udfc queries', function() {
-        assert.equal(18,
-                     udfForJSON('{"udf:plot:18.Action":"Watered", ' +
-                                '"udf:plot:18.Date":"2014-03-31"}'));
-    });
-    it('raises when multiple udfd ids are present', function() {
-        assert.throws(udfForJSON,
-                      '{"udf:plot:18.Action":"Watered", ' +
-                      '"udf:plot:19.Action":"Watered"}');
-    });
-    it('returns the correct udfd id for multi-predicate queries', function() {
-        assert.equal(18, udfForJSON('{"udf:plot:18.Action":"Watered", ' +
-                                    '"udf:plot:18.Date":"2014-03-31",' +
-                                    ' "tree.diameter": 15}'));
-    });
-});
-
-
 describe('testParseUdfCollectionFieldName', function() {
     it('returns the correct parsed object for udfc keys', function () {
         var results = utils.parseUdfCollectionFieldName('udf:plot:18.Action');

--- a/test/testFiltersToTables.js
+++ b/test/testFiltersToTables.js
@@ -67,18 +67,24 @@ describe('filtersToTables', function() {
         var sql = filtersToTables({"udf:tree:18.Action": {"LIKE": "%Watering%"}}, undefined);
         var expectedSql = "treemap_mapfeature LEFT OUTER JOIN treemap_tree " +
                 "ON treemap_mapfeature.id = treemap_tree.plot_id " +
-                "LEFT OUTER JOIN treemap_userdefinedcollectionvalue " +
-                "ON (treemap_tree.id = treemap_userdefinedcollectionvalue.model_id AND " +
-                "treemap_userdefinedcollectionvalue.field_definition_id = 18)";
+                "CROSS JOIN treemap_userdefinedcollectionvalue ";
         assert.equal(sql, expectedSql);
     });
 
     it('returns udfd/udcv and joins for udf mapfeature filter objects', function () {
         var sql = filtersToTables({"udf:plot:18.Action": {"LIKE": "%Watering%"}}, undefined);
         var expectedSql =
-                "treemap_mapfeature LEFT OUTER JOIN treemap_userdefinedcollectionvalue " +
-                "ON (treemap_mapfeature.id = treemap_userdefinedcollectionvalue.model_id AND " +
-                "treemap_userdefinedcollectionvalue.field_definition_id = 18)";
+                "treemap_mapfeature CROSS JOIN treemap_userdefinedcollectionvalue ";
+        assert.equal(sql, expectedSql);
+    });
+
+    it('returns udfd/udcv and joins to tree and mapfeature for udf tree and mapfeature filter objects', function () {
+        var sql = filtersToTables(["OR", {"udf:plot:18.Action": {"LIKE": "%Watering%"}},
+                                         {"udf:tree:17.Action": {"LIKE": "%Burning%"}}], undefined);
+        var expectedSql =
+                "treemap_mapfeature" +
+                " CROSS JOIN treemap_userdefinedcollectionvalue " +
+                " LEFT OUTER JOIN treemap_tree ON treemap_mapfeature.id = treemap_tree.plot_id ";
         assert.equal(sql, expectedSql);
     });
 });


### PR DESCRIPTION
The client must wrap the JSON objects for UDFCs in an ["OR", ...]
combinator, as we can't query for matches on multiple UDFC types for the
same row.

One note, in order to add the tree joins to the query only when necessary, the
"udf:plot" and "udf:tree" SQL are both empty, and depend on "udf".
This introduces some extra whitespace characters in the query, but doesn't hurt
anything.
