### PR TITLE
Add support for npm-shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,1554 @@
+{
+  "name": "otm2-tiler",
+  "version": "0.0.1-SNAPSHOT",
+  "dependencies": {
+    "moment": {
+      "version": "2.1.0",
+      "from": "moment@~2.1.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.1.0.tgz"
+    },
+    "semver": {
+      "version": "1.1.4",
+      "from": "semver@~1.1.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
+    },
+    "underscore": {
+      "version": "1.3.3",
+      "from": "underscore@~1.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz"
+    },
+    "windshaft": {
+      "version": "0.19.4",
+      "from": "windshaft@0.19.4",
+      "resolved": "https://registry.npmjs.org/windshaft/-/windshaft-0.19.4.tgz",
+      "dependencies": {
+        "step": {
+          "version": "0.0.5",
+          "from": "step@~0.0.5",
+          "resolved": "https://registry.npmjs.org/step/-/step-0.0.5.tgz"
+        },
+        "grainstore": {
+          "version": "0.18.1",
+          "from": "grainstore@~0.18.1",
+          "resolved": "https://registry.npmjs.org/grainstore/-/grainstore-0.18.1.tgz",
+          "dependencies": {
+            "redis-mpool": {
+              "version": "0.0.4",
+              "from": "http://github.com/CartoDB/node-redis-mpool/tarball/0.0.4",
+              "resolved": "http://github.com/CartoDB/node-redis-mpool/tarball/0.0.4",
+              "dependencies": {
+                "redis": {
+                  "version": "0.8.6",
+                  "from": "redis@~0.8.3",
+                  "resolved": "https://registry.npmjs.org/redis/-/redis-0.8.6.tgz"
+                },
+                "hiredis": {
+                  "version": "0.1.17",
+                  "from": "hiredis@~0.1.14",
+                  "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.1.17.tgz",
+                  "dependencies": {
+                    "bindings": {
+                      "version": "1.2.1",
+                      "from": "bindings@*",
+                      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+                    },
+                    "nan": {
+                      "version": "1.1.2",
+                      "from": "nan@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mapnik-reference": {
+              "version": "5.0.9",
+              "from": "mapnik-reference@~5.0.7",
+              "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-5.0.9.tgz"
+            },
+            "millstone": {
+              "version": "0.6.14",
+              "from": "millstone@~0.6.4",
+              "resolved": "https://registry.npmjs.org/millstone/-/millstone-0.6.14.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.6.0",
+                  "from": "underscore@~1.6.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                },
+                "request": {
+                  "version": "2.34.0",
+                  "from": "request@~2.34.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.34.0.tgz",
+                  "dependencies": {
+                    "qs": {
+                      "version": "0.6.6",
+                      "from": "qs@~0.6.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.0",
+                      "from": "json-stringify-safe@~5.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.1",
+                      "from": "node-uuid@~1.4.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "0.12.1",
+                      "from": "tough-cookie@>=0.12.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.3.1",
+                          "from": "punycode@>=0.2.0",
+                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.1.tgz"
+                        }
+                      }
+                    },
+                    "form-data": {
+                      "version": "0.1.4",
+                      "from": "form-data@~0.1.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "0.0.5",
+                          "from": "combined-stream@~0.0.4",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                            }
+                          }
+                        },
+                        "async": {
+                          "version": "0.9.0",
+                          "from": "async@~0.9.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                        }
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.3.0",
+                      "from": "tunnel-agent@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+                    },
+                    "http-signature": {
+                      "version": "0.10.0",
+                      "from": "http-signature@~0.10.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.2",
+                          "from": "assert-plus@0.1.2",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.2",
+                          "from": "ctype@0.5.2",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.3.0",
+                      "from": "oauth-sign@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "1.0.0",
+                      "from": "hawk@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@0.9.x",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@0.4.x",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@0.2.x",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@0.2.x",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "from": "aws-sign2@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                    }
+                  }
+                },
+                "srs": {
+                  "version": "0.4.3",
+                  "from": "srs@~0.4.1",
+                  "resolved": "https://registry.npmjs.org/srs/-/srs-0.4.3.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.2.0",
+                      "from": "nan@~1.2.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.2.0.tgz"
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.5.17",
+                      "from": "node-pre-gyp@0.5.x",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.5.17.tgz",
+                      "dependencies": {
+                        "nopt": {
+                          "version": "2.2.1",
+                          "from": "nopt@~2.2.0",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                          "dependencies": {
+                            "abbrev": {
+                              "version": "1.0.5",
+                              "from": "abbrev@1",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                            }
+                          }
+                        },
+                        "npmlog": {
+                          "version": "0.0.6",
+                          "from": "npmlog@~0.0.6",
+                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.0.6.tgz",
+                          "dependencies": {
+                            "ansi": {
+                              "version": "0.2.1",
+                              "from": "ansi@~0.2.1",
+                              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.2.1.tgz"
+                            }
+                          }
+                        },
+                        "request": {
+                          "version": "2.36.0",
+                          "from": "request@2",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
+                          "dependencies": {
+                            "qs": {
+                              "version": "0.6.6",
+                              "from": "qs@~0.6.0",
+                              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                            },
+                            "json-stringify-safe": {
+                              "version": "5.0.0",
+                              "from": "json-stringify-safe@~5.0.0",
+                              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                            },
+                            "mime": {
+                              "version": "1.2.11",
+                              "from": "mime@~1.2.9",
+                              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                            },
+                            "forever-agent": {
+                              "version": "0.5.2",
+                              "from": "forever-agent@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                            },
+                            "node-uuid": {
+                              "version": "1.4.1",
+                              "from": "node-uuid@~1.4.0",
+                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                            },
+                            "tough-cookie": {
+                              "version": "0.12.1",
+                              "from": "tough-cookie@>=0.12.0",
+                              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                              "dependencies": {
+                                "punycode": {
+                                  "version": "1.2.4",
+                                  "from": "punycode@>=0.2.0",
+                                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+                                }
+                              }
+                            },
+                            "form-data": {
+                              "version": "0.1.2",
+                              "from": "form-data@~0.1.0",
+                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
+                              "dependencies": {
+                                "combined-stream": {
+                                  "version": "0.0.4",
+                                  "from": "combined-stream@~0.0.4",
+                                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                                  "dependencies": {
+                                    "delayed-stream": {
+                                      "version": "0.0.5",
+                                      "from": "delayed-stream@0.0.5",
+                                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                                    }
+                                  }
+                                },
+                                "async": {
+                                  "version": "0.2.10",
+                                  "from": "async@~0.2.9",
+                                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                                }
+                              }
+                            },
+                            "tunnel-agent": {
+                              "version": "0.4.0",
+                              "from": "tunnel-agent@~0.4.0",
+                              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                            },
+                            "http-signature": {
+                              "version": "0.10.0",
+                              "from": "http-signature@~0.10.0",
+                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                              "dependencies": {
+                                "assert-plus": {
+                                  "version": "0.1.2",
+                                  "from": "assert-plus@0.1.2",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                                },
+                                "asn1": {
+                                  "version": "0.1.11",
+                                  "from": "asn1@0.1.11",
+                                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                                },
+                                "ctype": {
+                                  "version": "0.5.2",
+                                  "from": "ctype@0.5.2",
+                                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                                }
+                              }
+                            },
+                            "oauth-sign": {
+                              "version": "0.3.0",
+                              "from": "oauth-sign@~0.3.0",
+                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                            },
+                            "hawk": {
+                              "version": "1.0.0",
+                              "from": "hawk@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                              "dependencies": {
+                                "hoek": {
+                                  "version": "0.9.1",
+                                  "from": "hoek@0.9.x",
+                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                                },
+                                "boom": {
+                                  "version": "0.4.2",
+                                  "from": "boom@0.4.x",
+                                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                                },
+                                "cryptiles": {
+                                  "version": "0.2.2",
+                                  "from": "cryptiles@0.2.x",
+                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                                },
+                                "sntp": {
+                                  "version": "0.2.4",
+                                  "from": "sntp@0.2.x",
+                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                                }
+                              }
+                            },
+                            "aws-sign2": {
+                              "version": "0.5.0",
+                              "from": "aws-sign2@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "2.3.0",
+                          "from": "semver@~2.3.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.0.tgz"
+                        },
+                        "tar": {
+                          "version": "0.1.19",
+                          "from": "tar@~0.1.19",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
+                          "dependencies": {
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@2",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "block-stream": {
+                              "version": "0.0.7",
+                              "from": "block-stream@*",
+                              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                            },
+                            "fstream": {
+                              "version": "0.1.25",
+                              "from": "fstream@~0.1.8",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.25.tgz",
+                              "dependencies": {
+                                "mkdirp": {
+                                  "version": "0.3.5",
+                                  "from": "mkdirp@0.3",
+                                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                                },
+                                "graceful-fs": {
+                                  "version": "2.0.3",
+                                  "from": "graceful-fs@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "tar-pack": {
+                          "version": "2.0.0",
+                          "from": "tar-pack@~2.0.0",
+                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+                          "dependencies": {
+                            "uid-number": {
+                              "version": "0.0.3",
+                              "from": "uid-number@0.0.3",
+                              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                            },
+                            "once": {
+                              "version": "1.1.1",
+                              "from": "once@~1.1.1",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                            },
+                            "debug": {
+                              "version": "0.7.4",
+                              "from": "debug@~0.7.2",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                            },
+                            "fstream": {
+                              "version": "0.1.25",
+                              "from": "fstream@~0.1.22",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.25.tgz",
+                              "dependencies": {
+                                "mkdirp": {
+                                  "version": "0.3.5",
+                                  "from": "mkdirp@0.3",
+                                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                                },
+                                "graceful-fs": {
+                                  "version": "2.0.3",
+                                  "from": "graceful-fs@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "fstream-ignore": {
+                              "version": "0.0.7",
+                              "from": "fstream-ignore@0.0.7",
+                              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+                              "dependencies": {
+                                "minimatch": {
+                                  "version": "0.2.14",
+                                  "from": "minimatch@~0.2.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                                  "dependencies": {
+                                    "lru-cache": {
+                                      "version": "2.5.0",
+                                      "from": "lru-cache@2",
+                                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                                    },
+                                    "sigmund": {
+                                      "version": "1.0.0",
+                                      "from": "sigmund@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.27-1",
+                              "from": "readable-stream@~1.0.2",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@~1.0.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.25-1",
+                                  "from": "string_decoder@~0.10.x",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@1.2",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            }
+                          }
+                        },
+                        "mkdirp": {
+                          "version": "0.5.0",
+                          "from": "mkdirp@~0.5.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "minimist@0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "rc": {
+                          "version": "0.4.0",
+                          "from": "rc@~0.4.0",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.4.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.10",
+                              "from": "minimist@~0.0.7",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                            },
+                            "deep-extend": {
+                              "version": "0.2.10",
+                              "from": "deep-extend@~0.2.5",
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.10.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3",
+                              "from": "strip-json-comments@0.1.x",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                            },
+                            "ini": {
+                              "version": "1.1.0",
+                              "from": "ini@~1.1.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "rimraf@~2.2.5",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "zipfile": {
+                  "version": "0.5.3",
+                  "from": "zipfile@~0.5.2",
+                  "resolved": "https://registry.npmjs.org/zipfile/-/zipfile-0.5.3.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.2.0",
+                      "from": "nan@~1.2.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.2.0.tgz"
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.5.19",
+                      "from": "node-pre-gyp@0.5.x",
+                      "dependencies": {
+                        "nopt": {
+                          "version": "2.2.1",
+                          "from": "nopt@~2.2.0",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                          "dependencies": {
+                            "abbrev": {
+                              "version": "1.0.5",
+                              "from": "abbrev@1",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                            }
+                          }
+                        },
+                        "npmlog": {
+                          "version": "0.0.6",
+                          "from": "npmlog@~0.0.6",
+                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.0.6.tgz",
+                          "dependencies": {
+                            "ansi": {
+                              "version": "0.2.1",
+                              "from": "ansi@~0.2.1",
+                              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.2.1.tgz"
+                            }
+                          }
+                        },
+                        "request": {
+                          "version": "2.36.0",
+                          "from": "request@2",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
+                          "dependencies": {
+                            "qs": {
+                              "version": "0.6.6",
+                              "from": "qs@~0.6.0",
+                              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                            },
+                            "json-stringify-safe": {
+                              "version": "5.0.0",
+                              "from": "json-stringify-safe@~5.0.0",
+                              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                            },
+                            "mime": {
+                              "version": "1.2.11",
+                              "from": "mime@~1.2.9",
+                              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                            },
+                            "forever-agent": {
+                              "version": "0.5.2",
+                              "from": "forever-agent@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                            },
+                            "node-uuid": {
+                              "version": "1.4.1",
+                              "from": "node-uuid@~1.4.0",
+                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                            },
+                            "tough-cookie": {
+                              "version": "0.12.1",
+                              "from": "tough-cookie@>=0.12.0",
+                              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                              "dependencies": {
+                                "punycode": {
+                                  "version": "1.2.4",
+                                  "from": "punycode@>=0.2.0",
+                                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+                                }
+                              }
+                            },
+                            "form-data": {
+                              "version": "0.1.2",
+                              "from": "form-data@~0.1.0",
+                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
+                              "dependencies": {
+                                "combined-stream": {
+                                  "version": "0.0.4",
+                                  "from": "combined-stream@~0.0.4",
+                                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                                  "dependencies": {
+                                    "delayed-stream": {
+                                      "version": "0.0.5",
+                                      "from": "delayed-stream@0.0.5",
+                                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                                    }
+                                  }
+                                },
+                                "async": {
+                                  "version": "0.2.10",
+                                  "from": "async@~0.2.9",
+                                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                                }
+                              }
+                            },
+                            "tunnel-agent": {
+                              "version": "0.4.0",
+                              "from": "tunnel-agent@~0.4.0",
+                              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                            },
+                            "http-signature": {
+                              "version": "0.10.0",
+                              "from": "http-signature@~0.10.0",
+                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                              "dependencies": {
+                                "assert-plus": {
+                                  "version": "0.1.2",
+                                  "from": "assert-plus@0.1.2",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                                },
+                                "asn1": {
+                                  "version": "0.1.11",
+                                  "from": "asn1@0.1.11",
+                                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                                },
+                                "ctype": {
+                                  "version": "0.5.2",
+                                  "from": "ctype@0.5.2",
+                                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                                }
+                              }
+                            },
+                            "oauth-sign": {
+                              "version": "0.3.0",
+                              "from": "oauth-sign@~0.3.0",
+                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                            },
+                            "hawk": {
+                              "version": "1.0.0",
+                              "from": "hawk@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                              "dependencies": {
+                                "hoek": {
+                                  "version": "0.9.1",
+                                  "from": "hoek@0.9.x",
+                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                                },
+                                "boom": {
+                                  "version": "0.4.2",
+                                  "from": "boom@0.4.x",
+                                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                                },
+                                "cryptiles": {
+                                  "version": "0.2.2",
+                                  "from": "cryptiles@0.2.x",
+                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                                },
+                                "sntp": {
+                                  "version": "0.2.4",
+                                  "from": "sntp@0.2.x",
+                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                                }
+                              }
+                            },
+                            "aws-sign2": {
+                              "version": "0.5.0",
+                              "from": "aws-sign2@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "2.3.0",
+                          "from": "semver@~2.3.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.0.tgz"
+                        },
+                        "tar": {
+                          "version": "0.1.19",
+                          "from": "tar@~0.1.19",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
+                          "dependencies": {
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@2",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "block-stream": {
+                              "version": "0.0.7",
+                              "from": "block-stream@*",
+                              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                            },
+                            "fstream": {
+                              "version": "0.1.25",
+                              "from": "fstream@~0.1.8",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.25.tgz",
+                              "dependencies": {
+                                "mkdirp": {
+                                  "version": "0.3.5",
+                                  "from": "mkdirp@0.3",
+                                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                                },
+                                "graceful-fs": {
+                                  "version": "2.0.3",
+                                  "from": "graceful-fs@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "tar-pack": {
+                          "version": "2.0.0",
+                          "from": "tar-pack@~2.0.0",
+                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+                          "dependencies": {
+                            "uid-number": {
+                              "version": "0.0.3",
+                              "from": "uid-number@0.0.3",
+                              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                            },
+                            "once": {
+                              "version": "1.1.1",
+                              "from": "once@~1.1.1",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                            },
+                            "debug": {
+                              "version": "0.7.4",
+                              "from": "debug@~0.7.2",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                            },
+                            "fstream": {
+                              "version": "0.1.25",
+                              "from": "fstream@~0.1.22",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.25.tgz",
+                              "dependencies": {
+                                "mkdirp": {
+                                  "version": "0.3.5",
+                                  "from": "mkdirp@0.3",
+                                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                                },
+                                "graceful-fs": {
+                                  "version": "2.0.3",
+                                  "from": "graceful-fs@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "fstream-ignore": {
+                              "version": "0.0.7",
+                              "from": "fstream-ignore@0.0.7",
+                              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+                              "dependencies": {
+                                "minimatch": {
+                                  "version": "0.2.14",
+                                  "from": "minimatch@~0.2.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                                  "dependencies": {
+                                    "lru-cache": {
+                                      "version": "2.5.0",
+                                      "from": "lru-cache@2",
+                                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                                    },
+                                    "sigmund": {
+                                      "version": "1.0.0",
+                                      "from": "sigmund@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.27-1",
+                              "from": "readable-stream@~1.0.2",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@~1.0.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.25-1",
+                                  "from": "string_decoder@~0.10.x",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@1.2",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            }
+                          }
+                        },
+                        "mkdirp": {
+                          "version": "0.5.0",
+                          "from": "mkdirp@~0.5.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "minimist@0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "rc": {
+                          "version": "0.4.0",
+                          "from": "rc@~0.4.0",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.4.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.10",
+                              "from": "minimist@~0.0.7",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                            },
+                            "deep-extend": {
+                              "version": "0.2.10",
+                              "from": "deep-extend@~0.2.5",
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.10.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3",
+                              "from": "strip-json-comments@0.1.x",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                            },
+                            "ini": {
+                              "version": "1.1.0",
+                              "from": "ini@~1.1.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "rimraf@~2.2.5",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "sqlite3": {
+                  "version": "2.2.7",
+                  "from": "sqlite3@2.x",
+                  "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-2.2.7.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.1.2",
+                      "from": "nan@1.1.2",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.5.22",
+                      "from": "node-pre-gyp@0.5.22",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.5.22.tgz",
+                      "dependencies": {
+                        "nopt": {
+                          "version": "3.0.1",
+                          "from": "nopt@~3.0.1",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+                          "dependencies": {
+                            "abbrev": {
+                              "version": "1.0.5",
+                              "from": "abbrev@1",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                            }
+                          }
+                        },
+                        "npmlog": {
+                          "version": "0.1.1",
+                          "from": "npmlog@~0.1.1",
+                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.1.1.tgz",
+                          "dependencies": {
+                            "ansi": {
+                              "version": "0.3.0",
+                              "from": "ansi@~0.3.0",
+                              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                            }
+                          }
+                        },
+                        "request": {
+                          "version": "2.39.0",
+                          "from": "request@2.x",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.39.0.tgz",
+                          "dependencies": {
+                            "qs": {
+                              "version": "0.6.6",
+                              "from": "qs@~0.6.0",
+                              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                            },
+                            "json-stringify-safe": {
+                              "version": "5.0.0",
+                              "from": "json-stringify-safe@~5.0.0",
+                              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                            },
+                            "mime-types": {
+                              "version": "1.0.2",
+                              "from": "mime-types@~1.0.1",
+                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                            },
+                            "forever-agent": {
+                              "version": "0.5.2",
+                              "from": "forever-agent@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                            },
+                            "node-uuid": {
+                              "version": "1.4.1",
+                              "from": "node-uuid@~1.4.0",
+                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                            },
+                            "tough-cookie": {
+                              "version": "0.12.1",
+                              "from": "tough-cookie@>=0.12.0",
+                              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                              "dependencies": {
+                                "punycode": {
+                                  "version": "1.3.0",
+                                  "from": "punycode@>=0.2.0",
+                                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.0.tgz"
+                                }
+                              }
+                            },
+                            "form-data": {
+                              "version": "0.1.4",
+                              "from": "form-data@~0.1.0",
+                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                              "dependencies": {
+                                "combined-stream": {
+                                  "version": "0.0.5",
+                                  "from": "combined-stream@~0.0.4",
+                                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
+                                  "dependencies": {
+                                    "delayed-stream": {
+                                      "version": "0.0.5",
+                                      "from": "delayed-stream@0.0.5",
+                                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                                    }
+                                  }
+                                },
+                                "mime": {
+                                  "version": "1.2.11",
+                                  "from": "mime@~1.2.11",
+                                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                                },
+                                "async": {
+                                  "version": "0.9.0",
+                                  "from": "async@~0.9.0",
+                                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                                }
+                              }
+                            },
+                            "tunnel-agent": {
+                              "version": "0.4.0",
+                              "from": "tunnel-agent@~0.4.0",
+                              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                            },
+                            "http-signature": {
+                              "version": "0.10.0",
+                              "from": "http-signature@~0.10.0",
+                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                              "dependencies": {
+                                "assert-plus": {
+                                  "version": "0.1.2",
+                                  "from": "assert-plus@0.1.2",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                                },
+                                "asn1": {
+                                  "version": "0.1.11",
+                                  "from": "asn1@0.1.11",
+                                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                                },
+                                "ctype": {
+                                  "version": "0.5.2",
+                                  "from": "ctype@0.5.2",
+                                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                                }
+                              }
+                            },
+                            "oauth-sign": {
+                              "version": "0.3.0",
+                              "from": "oauth-sign@~0.3.0",
+                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                            },
+                            "hawk": {
+                              "version": "1.1.1",
+                              "from": "hawk@1.1.1",
+                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                              "dependencies": {
+                                "hoek": {
+                                  "version": "0.9.1",
+                                  "from": "hoek@0.9.x",
+                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                                },
+                                "boom": {
+                                  "version": "0.4.2",
+                                  "from": "boom@0.4.x",
+                                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                                },
+                                "cryptiles": {
+                                  "version": "0.2.2",
+                                  "from": "cryptiles@0.2.x",
+                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                                },
+                                "sntp": {
+                                  "version": "0.2.4",
+                                  "from": "sntp@0.2.x",
+                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                                }
+                              }
+                            },
+                            "aws-sign2": {
+                              "version": "0.5.0",
+                              "from": "aws-sign2@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                            },
+                            "stringstream": {
+                              "version": "0.0.4",
+                              "from": "stringstream@~0.0.4",
+                              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "3.0.1",
+                          "from": "semver@~3.0.1",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-3.0.1.tgz"
+                        },
+                        "tar": {
+                          "version": "1.0.0",
+                          "from": "tar@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.0.tgz",
+                          "dependencies": {
+                            "block-stream": {
+                              "version": "0.0.7",
+                              "from": "block-stream@*",
+                              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                            },
+                            "fstream": {
+                              "version": "1.0.1",
+                              "from": "fstream@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.1.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "3.0.2",
+                                  "from": "graceful-fs@3",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "tar-pack": {
+                          "version": "2.0.0",
+                          "from": "tar-pack@~2.0.0",
+                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+                          "dependencies": {
+                            "uid-number": {
+                              "version": "0.0.3",
+                              "from": "uid-number@0.0.3",
+                              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                            },
+                            "once": {
+                              "version": "1.1.1",
+                              "from": "once@~1.1.1",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                            },
+                            "debug": {
+                              "version": "0.7.4",
+                              "from": "debug@~0.7.2",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                            },
+                            "fstream": {
+                              "version": "0.1.31",
+                              "from": "fstream@~0.1.22",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "3.0.2",
+                                  "from": "graceful-fs@3",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.2.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@2",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "tar": {
+                              "version": "0.1.20",
+                              "from": "tar@~0.1.17",
+                              "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                              "dependencies": {
+                                "block-stream": {
+                                  "version": "0.0.7",
+                                  "from": "block-stream@*",
+                                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@2",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "fstream-ignore": {
+                              "version": "0.0.7",
+                              "from": "fstream-ignore@0.0.7",
+                              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+                              "dependencies": {
+                                "minimatch": {
+                                  "version": "0.2.14",
+                                  "from": "minimatch@~0.2.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                                  "dependencies": {
+                                    "lru-cache": {
+                                      "version": "2.5.0",
+                                      "from": "lru-cache@2",
+                                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                                    },
+                                    "sigmund": {
+                                      "version": "1.0.0",
+                                      "from": "sigmund@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@2",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.27-1",
+                              "from": "readable-stream@~1.0.2",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@~1.0.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.25-1",
+                                  "from": "string_decoder@~0.10.x",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@2",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@1.2",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            }
+                          }
+                        },
+                        "mkdirp": {
+                          "version": "0.5.0",
+                          "from": "mkdirp@~0.5.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "minimist@0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "rc": {
+                          "version": "0.5.0",
+                          "from": "rc@~0.5.0",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.10",
+                              "from": "minimist@~0.0.7",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                            },
+                            "deep-extend": {
+                              "version": "0.2.11",
+                              "from": "deep-extend@~0.2.5",
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3",
+                              "from": "strip-json-comments@0.1.x",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                            },
+                            "ini": {
+                              "version": "1.1.0",
+                              "from": "ini@~1.1.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "rimraf@~2.2.8",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        }
+                      }
+                    },
+                    "set-immediate": {
+                      "version": "0.1.1",
+                      "from": "set-immediate@0.1.1",
+                      "resolved": "https://registry.npmjs.org/set-immediate/-/set-immediate-0.1.1.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@~1.2.9",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@~0.3.3",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@~0.6.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@~0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@~0.0.1",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "generic-pool": {
+          "version": "2.0.4",
+          "from": "generic-pool@~2.0.3",
+          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.4.tgz"
+        },
+        "express": {
+          "version": "2.5.11",
+          "from": "express@~2.5.11",
+          "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
+          "dependencies": {
+            "connect": {
+              "version": "1.9.2",
+              "from": "connect@1.x",
+              "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
+              "dependencies": {
+                "formidable": {
+                  "version": "1.0.15",
+                  "from": "formidable@1.0.x",
+                  "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.15.tgz"
+                }
+              }
+            },
+            "mime": {
+              "version": "1.2.4",
+              "from": "mime@1.2.4",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz"
+            },
+            "qs": {
+              "version": "0.4.2",
+              "from": "qs@0.4.x",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.0",
+              "from": "mkdirp@0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+            }
+          }
+        },
+        "tilelive": {
+          "version": "4.4.3",
+          "from": "tilelive@~4.4.2",
+          "resolved": "https://registry.npmjs.org/tilelive/-/tilelive-4.4.3.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@~0.3.1",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@~0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
+            },
+            "sphericalmercator": {
+              "version": "1.0.2",
+              "from": "sphericalmercator@~1.0.1",
+              "resolved": "https://registry.npmjs.org/sphericalmercator/-/sphericalmercator-1.0.2.tgz"
+            }
+          }
+        },
+        "tilelive-mapnik": {
+          "version": "0.6.10",
+          "from": "tilelive-mapnik@~0.6.5",
+          "resolved": "https://registry.npmjs.org/tilelive-mapnik/-/tilelive-mapnik-0.6.10.tgz",
+          "dependencies": {
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@~1.2.9",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            },
+            "sphericalmercator": {
+              "version": "1.0.2",
+              "from": "sphericalmercator@~1.0.1",
+              "resolved": "https://registry.npmjs.org/sphericalmercator/-/sphericalmercator-1.0.2.tgz"
+            }
+          }
+        },
+        "mapnik": {
+          "version": "0.7.28",
+          "from": "mapnik@~0.7.17",
+          "resolved": "https://registry.npmjs.org/mapnik/-/mapnik-0.7.28.tgz"
+        },
+        "redis-mpool": {
+          "version": "0.0.3",
+          "from": "redis-mpool@~0.0.2",
+          "resolved": "https://registry.npmjs.org/redis-mpool/-/redis-mpool-0.0.3.tgz",
+          "dependencies": {
+            "redis": {
+              "version": "0.8.6",
+              "from": "redis@~0.8.3",
+              "resolved": "https://registry.npmjs.org/redis/-/redis-0.8.6.tgz"
+            },
+            "hiredis": {
+              "version": "0.1.17",
+              "from": "hiredis@~0.1.14",
+              "resolved": "https://registry.npmjs.org/hiredis/-/hiredis-0.1.17.tgz",
+              "dependencies": {
+                "bindings": {
+                  "version": "1.2.1",
+                  "from": "bindings@*",
+                  "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+                },
+                "nan": {
+                  "version": "1.1.2",
+                  "from": "nan@~1.1.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "lru-cache": {
+          "version": "2.3.1",
+          "from": "lru-cache@~2.3.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
+        },
+        "carto": {
+          "version": "0.9.5-cdb2",
+          "from": "http://github.com/CartoDB/carto/tarball/0.9.5-cdb2",
+          "resolved": "http://github.com/CartoDB/carto/tarball/0.9.5-cdb2",
+          "dependencies": {
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@~1.4.3",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "mapnik-reference": {
+              "version": "5.0.9",
+              "from": "mapnik-reference@~5.0.7",
+              "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-5.0.9.tgz"
+            },
+            "xml2js": {
+              "version": "0.2.8",
+              "from": "xml2js@~0.2.4",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+              "dependencies": {
+                "sax": {
+                  "version": "0.5.8",
+                  "from": "sax@0.5.x",
+                  "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
+                }
+              }
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@~0.6.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@~0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@~0.0.1",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            }
+          }
+        },
+        "underscore.string": {
+          "version": "1.1.6",
+          "from": "underscore.string@~1.1.6",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-1.1.6.tgz",
+          "dependencies": {
+            "underscore": {
+              "version": "1.1.7",
+              "from": "underscore@1.1.7",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz"
+            }
+          }
+        },
+        "pg": {
+          "version": "2.6.2",
+          "from": "pg@~2.6.2",
+          "resolved": "https://registry.npmjs.org/pg/-/pg-2.6.2.tgz",
+          "dependencies": {
+            "generic-pool": {
+              "version": "2.0.3",
+              "from": "generic-pool@2.0.3",
+              "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.0.3.tgz"
+            },
+            "buffer-writer": {
+              "version": "1.0.0",
+              "from": "buffer-writer@1.0.0",
+              "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz"
+            }
+          }
+        },
+        "torque.js": {
+          "version": "2.2.0",
+          "from": "torque.js@~2.2.00",
+          "resolved": "https://registry.npmjs.org/torque.js/-/torque.js-2.2.00.tgz"
+        },
+        "node-statsd": {
+          "version": "0.0.7",
+          "from": "node-statsd@~0.0.7",
+          "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.0.7.tgz"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Shrinkwrap locks down the versions of a package's dependencies so that you can control exactly which versions of each dependency will be used when your package is installed.

(The `package.json` file is still required if you want to use `npm install`.)

**To install dependencies**:

Using a shrinkwrapped package is no different than using any other package: you can `npm install` it by hand, or add a dependency to your `package.json` file and `npm install` it.

**To add or update a dependency**:
- Run `npm install` in the package root to install the current versions of all dependencies
- Add or update dependencies
- `npm install` each new or updated package individually
- Validate that the package works as expected with the new dependencies
- Run `npm shrinkwrap`, commit the new `npm-shrinkwrap.json`

**Note**: Dependencies must be explicitly named in order to be installed: running `npm install` with no arguments will merely reproduce the existing shrinkwrap.

Resolves: https://github.com/OpenTreeMap/OTM2-tiler/issues/28
