### PR TITLE
Move CartoCSS styles into the tiler repository

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,13 +2,20 @@
 
 var Windshaft = require('windshaft');
 var _ = require('underscore');
+var cluster = require('cluster');
+var fs = require('fs');
 var makeSql = require('./makeSql.js');
 var config = require('./config.json');
 var settings = require('./settings.json');
-var cluster = require('cluster');
+
 var workerCount = process.env.WORKERS || require('os').cpus().length;
 var port = process.env.PORT || 4000;
 var ws;
+
+var styles = {
+    boundary: fs.readFileSync('style/boundary.mms', {encoding: 'utf-8'}),
+    mapfeature: fs.readFileSync('style/mapfeature.mms', {encoding: 'utf-8'})
+};
 
 // Configure the Windshaft tile server to handle OTM's HTTP requests, which retrieve
 // e.g. a map tile or UTF grid with map features like tree plots or boundaries.
@@ -71,8 +78,10 @@ var windshaftConfig = {
                                                               instanceid,
                                                               zoom,
                                                               isUtfGridRequest);
+                req.params.style = styles.mapfeature;
             } else if (table === 'treemap_boundary' && instanceid) {
                 req.query.sql = makeSql.makeSqlForBoundaries(instanceid);
+                req.params.style = styles.boundary;
             }
         } catch (err) {
             callback(err, null);

--- a/style/boundary.mms
+++ b/style/boundary.mms
@@ -1,0 +1,21 @@
+#treemap_boundary {
+	::case {
+    	line-width: 5;
+    	line-color:#ddd;
+    	line-opacity: 0.4;
+  	}
+  	::fill {
+    	line-width: 0.5;
+    	line-color: #444;
+    	line-dasharray: 10, 8;
+  	}
+
+    [zoom < 16] {
+        ::case {
+    	    line-width: 0;    
+        }
+        ::fill {
+            line-width: 0;  
+        }
+    }
+}

--- a/style/boundary.mms
+++ b/style/boundary.mms
@@ -1,21 +1,21 @@
 #treemap_boundary {
-	::case {
-    	line-width: 5;
-    	line-color:#ddd;
-    	line-opacity: 0.4;
-  	}
-  	::fill {
-    	line-width: 0.5;
-    	line-color: #444;
-    	line-dasharray: 10, 8;
-  	}
+    ::case {
+        line-width: 5;
+        line-color:#ddd;
+        line-opacity: 0.4;
+    }
+    ::fill {
+        line-width: 0.5;
+        line-color: #444;
+        line-dasharray: 10, 8;
+    }
 
     [zoom < 16] {
         ::case {
-    	    line-width: 0;    
+            line-width: 0;
         }
         ::fill {
-            line-width: 0;  
+            line-width: 0;
         }
     }
 }

--- a/style/mapfeature.mms
+++ b/style/mapfeature.mms
@@ -1,0 +1,38 @@
+#treemap_mapfeature {
+    [feature_type="Plot"] {
+        marker-fill: #8BAA3D;
+    }
+
+    [feature_type!="Plot"] {
+        marker-fill: #388E8E;
+    }
+
+    marker-allow-overlap: true;
+
+
+    [zoom >= 15] {
+        marker-line-color: #b6ce78;
+        marker-line-width: 1;
+    }
+    [zoom < 15] {
+       marker-line-width: 0;
+    }
+
+
+    [zoom >= 18] {
+       marker-width: 20;
+    }
+    [zoom = 17] {
+       marker-width: 15;
+    }
+    [zoom = 16] {
+       marker-width: 12;
+    }
+    [zoom = 15] {
+       marker-width: 8;
+    }
+    [zoom <= 14] {
+       marker-width: 5;
+    }
+
+}

--- a/style/mapfeature.mms
+++ b/style/mapfeature.mms
@@ -15,24 +15,24 @@
         marker-line-width: 1;
     }
     [zoom < 15] {
-       marker-line-width: 0;
+        marker-line-width: 0;
     }
 
 
     [zoom >= 18] {
-       marker-width: 20;
+        marker-width: 20;
     }
     [zoom = 17] {
-       marker-width: 15;
+        marker-width: 15;
     }
     [zoom = 16] {
-       marker-width: 12;
+        marker-width: 12;
     }
     [zoom = 15] {
-       marker-width: 8;
+        marker-width: 8;
     }
     [zoom <= 14] {
-       marker-width: 5;
+        marker-width: 5;
     }
 
 }


### PR DESCRIPTION
We had previously been applying these CartoCSS styles by POSTing to a
special Windshaft endpoint.

We're moving them into the tiler repo itself and applying them as part
request handler to simplify things a bit.

Connects to #61