### PR TITLE
Restrict tiler results to plots if a tree field is used in the filter

### DIFF
--- a/displayFiltersToWhere.js
+++ b/displayFiltersToWhere.js
@@ -5,12 +5,29 @@ var _ = require('underscore'),
     utils = require('./filterObjectUtils'),
     config = require('./config.json');
 
-module.exports = function(displayFilters) {
+module.exports = function(displayFilters, models) {
     var featureTypes, inClause;
 
-    if (_.isUndefined(displayFilters) || _.isNull(displayFilters)) {
-        throw new Error('A null or undefined display filter list cannot be converted to SQL');
+    if ( ! _.isArray(models) || models.length === 0) {
+        throw new Error('The models list must be a non-empty array.');
     }
+
+    // If there are trees referenced in the models list, narrow the display
+    // filters to only tree display filters.
+    if (_.contains(models, 'tree')) {
+        if (_.isArray(displayFilters) && displayFilters.length > 0) {
+            displayFilters = _.intersection(displayFilters, ['Tree', 'Plot', 'EmptyPlot']);
+        } else {
+            displayFilters = ['Plot'];
+        }
+    }
+
+    // If there are still no display filters (none from query args, and we're
+    // not filtering trees), return `null` to indicate that there is no SQL generated
+    if (_.isUndefined(displayFilters) || _.isNull(displayFilters)) {
+        return null;
+    }
+
     if ( ! _.isArray(displayFilters)) {
         throw new Error('The display filter list must be a list to be converted to SQL');
     }

--- a/displayFiltersToWhere.js
+++ b/displayFiltersToWhere.js
@@ -36,7 +36,7 @@ module.exports = function(displayFilters) {
             }
             filter = 'Plot';
         }
-        modelNameString = utils.convertValueToEscapedSqlLiteral (filter);
+        modelNameString = utils.convertValueToEscapedSqlLiteral(filter);
         modelSql = format('"%s"."feature_type" = %s', config.modelMapping.mapFeature, modelNameString);
         if (treeSql) {
             return format("(%s) AND (%s)", treeSql, modelSql);

--- a/docs/displayFiltersToWhere.html
+++ b/docs/displayFiltersToWhere.html
@@ -78,16 +78,12 @@
     utils = require(<span class="string">'./filterObjectUtils'</span>),
     config = require(<span class="string">'./config.json'</span>);
 
-module.exports = <span class="keyword">function</span>(displayFilters) {
+module.exports = <span class="keyword">function</span>(displayFilters, models) {
     <span class="keyword">var</span> featureTypes, inClause;
 
-    <span class="keyword">if</span> (_.isUndefined(displayFilters) || _.isNull(displayFilters)) {
-        <span class="keyword">throw</span> <span class="keyword">new</span> Error(<span class="string">'A null or undefined display filter list cannot be converted to SQL'</span>);
-    }
-    <span class="keyword">if</span> ( ! _.isArray(displayFilters)) {
-        <span class="keyword">throw</span> <span class="keyword">new</span> Error(<span class="string">'The display filter list must be a list to be converted to SQL'</span>);
-    }
-    <span class="keyword">if</span> (_.isEmpty(displayFilters)) {</pre></div></div>
+    <span class="keyword">if</span> ( ! _.isArray(models) || models.length === <span class="number">0</span>) {
+        <span class="keyword">throw</span> <span class="keyword">new</span> Error(<span class="string">'The models list must be a non-empty array.'</span>);
+    }</pre></div></div>
             
         </li>
         
@@ -97,6 +93,51 @@ module.exports = <span class="keyword">function</span>(displayFilters) {
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-2">&#182;</a>
+              </div>
+              <p>If there are trees referenced in the models list, narrow the display
+filters to only tree display filters.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="keyword">if</span> (_.contains(models, <span class="string">'tree'</span>)) {
+        <span class="keyword">if</span> (_.isArray(displayFilters) &amp;&amp; displayFilters.length &gt; <span class="number">0</span>) {
+            displayFilters = _.intersection(displayFilters, [<span class="string">'Tree'</span>, <span class="string">'Plot'</span>, <span class="string">'EmptyPlot'</span>]);
+        } <span class="keyword">else</span> {
+            displayFilters = [<span class="string">'Plot'</span>];
+        }
+    }</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-3">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-3">&#182;</a>
+              </div>
+              <p>If there are still no display filters (none from query args, and we&#39;re
+not filtering trees), return <code>null</code> to indicate that there is no SQL generated</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="keyword">if</span> (_.isUndefined(displayFilters) || _.isNull(displayFilters)) {
+        <span class="keyword">return</span> <span class="literal">null</span>;
+    }
+
+    <span class="keyword">if</span> ( ! _.isArray(displayFilters)) {
+        <span class="keyword">throw</span> <span class="keyword">new</span> Error(<span class="string">'The display filter list must be a list to be converted to SQL'</span>);
+    }
+    <span class="keyword">if</span> (_.isEmpty(displayFilters)) {</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-4">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-4">&#182;</a>
               </div>
               <p>With empty display filters, nothing should ever be shown
 &#39;WHERE FALSE&#39; should override any other filters</p>

--- a/docs/displayFiltersToWhere.html
+++ b/docs/displayFiltersToWhere.html
@@ -122,7 +122,7 @@ module.exports = <span class="keyword">function</span>(displayFilters) {
             }
             filter = <span class="string">'Plot'</span>;
         }
-        modelNameString = utils.convertValueToEscapedSqlLiteral (filter);
+        modelNameString = utils.convertValueToEscapedSqlLiteral(filter);
         modelSql = format(<span class="string">'"%s"."feature_type" = %s'</span>, config.modelMapping.mapFeature, modelNameString);
         <span class="keyword">if</span> (treeSql) {
             <span class="keyword">return</span> format(<span class="string">"(%s) AND (%s)"</span>, treeSql, modelSql);

--- a/docs/filterObjectToWhere.html
+++ b/docs/filterObjectToWhere.html
@@ -86,7 +86,7 @@
 SQL WHERE clause.</p>
 <p>A filter string must be valid JSON and conform to the following grammar:</p>
 <pre><code>literal        = json literal | GMT date string in &#39;YYYY-MM-DD HH:mm:ss&#39;
-model-name     = &#39;mapFeature&#39; | &#39;tree&#39; | &#39;species&#39; | &#39;treePhoto&#39;
+model-name     = &#39;mapFeature&#39; | &#39;tree&#39; | &#39;species&#39; | &#39;mapFeaturePhoto&#39;
 model          = &#39;udf:&#39;model-name | model-name
 value-property = &#39;MIN&#39;
                | &#39;MAX&#39;
@@ -105,9 +105,10 @@ filter         = predicate
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="keyword">var</span> _ = require(<span class="string">'underscore'</span>);
-<span class="keyword">var</span> config = require(<span class="string">'./config.json'</span>);
-<span class="keyword">var</span> utils = require(<span class="string">'./filterObjectUtils'</span>);</pre></div></div>
+            <div class="content"><div class='highlight'><pre><span class="keyword">var</span> _ = require(<span class="string">'underscore'</span>),
+    config = require(<span class="string">'./config.json'</span>),
+    utils = require(<span class="string">'./filterObjectUtils'</span>),
+    format = require(<span class="string">'util'</span>).format;</pre></div></div>
             
         </li>
         
@@ -293,7 +294,7 @@ accessHStore(&#39;grab_bag&#39;, &#39;is_valid&#39;) -&gt; &quot;grab_bag&quot;-
             <div class="content"><div class='highlight'><pre>    <span class="keyword">var</span> t = _.template(<span class="string">'"&lt;%= hStoreColumn %&gt;"-&gt;\'&lt;%= accessor %&gt;\''</span>);
     <span class="keyword">return</span> t({hStoreColumn: hStoreColumn,
               accessor: accessor.replace(<span class="string">"'"</span>,<span class="string">"''"</span>)});
-};</pre></div></div>
+}</pre></div></div>
             
         </li>
         
@@ -611,12 +612,7 @@ an underscore template</p>
             
             <div class="content"><div class='highlight'><pre>        <span class="keyword">if</span> (f.sql_template) {
             <span class="keyword">return</span> _.template(f.sql_template, { <span class="string">'column'</span>: columnName });
-        } <span class="keyword">else</span> {
-            <span class="keyword">return</span> columnName + <span class="string">' '</span> + f.matcher + <span class="string">' '</span> + f.value;
-        }
-    });
-    <span class="keyword">return</span> <span class="string">'('</span> + filterStatements.join(<span class="string">' AND '</span>) + <span class="string">')'</span> ;
-}</pre></div></div>
+        } <span class="keyword">else</span> {</pre></div></div>
             
         </li>
         
@@ -626,6 +622,54 @@ an underscore template</p>
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-25">&#182;</a>
+              </div>
+              <p>if the column is an hstore field and the value is a
+datestring literal the hstore field must be converted
+from text to date before comparsion</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>            <span class="keyword">if</span> (columnName.indexOf(<span class="string">'-&gt;'</span>) !== -<span class="number">1</span> &amp;&amp; f.value.indexOf(<span class="string">'(DATE'</span>) === <span class="number">0</span>) {
+                columnName = format(
+                    <span class="string">"to_date(%s::text, '%s')"</span>,
+                    columnName, utils.DATETIME_FORMATS.date);
+            }
+            <span class="keyword">return</span> columnName + <span class="string">' '</span> + f.matcher + <span class="string">' '</span> + f.value;
+        }
+    });</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-26">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-26">&#182;</a>
+              </div>
+              <p>If this is a query for collection UDFs, we need extra information in the
+WHERE clause to act as a join criteria, since the table is CROSS JOINed</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="keyword">if</span> (fieldName.indexOf(<span class="string">'udf:'</span>) === <span class="number">0</span>) {
+        <span class="keyword">var</span> udfCollectionData = utils.parseUdfCollectionFieldName(fieldName);
+        <span class="keyword">var</span> model = udfCollectionData.modelName;
+        <span class="keyword">var</span> udfcTemplate = _.template(config.udfcTemplates[model]);
+
+        filterStatements.push(udfcTemplate({fieldDefId: udfCollectionData.fieldDefId}));
+    }
+    <span class="keyword">return</span> <span class="string">'('</span> + filterStatements.join(<span class="string">' AND '</span>) + <span class="string">')'</span> ;
+}</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-27">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-27">&#182;</a>
               </div>
               <p><code>objectToSql</code> converts a filter object to a valid SQL WHERE clause.</p>
 
@@ -651,11 +695,11 @@ an underscore template</p>
         </li>
         
         
-        <li id="section-26">
+        <li id="section-28">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-26">&#182;</a>
+                <a class="pilcrow" href="#section-28">&#182;</a>
               </div>
               <p><code>arrayToSql</code> converts a combinator array into a valid SQL WHERE clause.</p>
 
@@ -672,11 +716,11 @@ an underscore template</p>
         </li>
         
         
-        <li id="section-27">
+        <li id="section-29">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-27">&#182;</a>
+                <a class="pilcrow" href="#section-29">&#182;</a>
               </div>
               <p><code>filterToSql</code> converts any filter object or combinator array into a valid SQL WHERE clause.</p>
 

--- a/docs/filterObjectUtils.html
+++ b/docs/filterObjectUtils.html
@@ -190,6 +190,8 @@ into the correct Postgres literal, and converting null into the string NULL.</p>
         <span class="keyword">return</span> value;
     } <span class="keyword">else</span> <span class="keyword">if</span> (value === <span class="literal">null</span>) {
         <span class="keyword">return</span> <span class="string">"NULL"</span>;
+    } <span class="keyword">else</span> <span class="keyword">if</span> (_.isBoolean(value)) {
+        <span class="keyword">return</span> value ? <span class="string">"TRUE"</span> : <span class="string">"FALSE"</span>;
     } <span class="keyword">else</span> <span class="keyword">if</span> (isDateTimeString(value)) {
         <span class="keyword">return</span> dateTimeStringToSqlValue(value);
     } <span class="keyword">else</span> {
@@ -261,39 +263,7 @@ syntax into an object of the relevant components.</p>
         fieldDefId: fieldDefIdAndHStoreMember[<span class="number">0</span>],
         hStoreMember: fieldDefIdAndHStoreMember[<span class="number">1</span>]
     };
-}</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-10">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-10">&#182;</a>
-              </div>
-              <p><code>getUdfFieldDefId</code> examines a filterObject to determine if it has
-predicates for <code>(python)UserDefinedCollectionValues</code>. This is
-necessary for adding an additional component to the where clause to
-filter on the <code>(python)UserDefinedFieldDefinition</code> id.  When ids
-are found, they are validated not to allow multiple ids, which are
-not supported.  returns null for non UDCV queries.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre><span class="function"><span class="keyword">function</span> <span class="title">getUdfFieldDefId</span> <span class="params">(filterObject)</span> {</span>
-    <span class="keyword">var</span> udfCollectionValues = _.reject(_(_.keys(filterObject)).map(parseUdfCollectionFieldName), _.isNull),
-        udfFieldDefIds = _.uniq(_.pluck(udfCollectionValues, <span class="string">'fieldDefId'</span>));
-    <span class="keyword">if</span> (udfFieldDefIds.length === <span class="number">1</span>) {
-        <span class="keyword">return</span> udfFieldDefIds[<span class="number">0</span>];
-    } <span class="keyword">else</span> <span class="keyword">if</span> (udfFieldDefIds.length === <span class="number">0</span>) {
-        <span class="keyword">return</span> <span class="literal">null</span>;
-    } <span class="keyword">else</span> {
-        <span class="keyword">throw</span> (<span class="string">"Multiple UserDefinedFieldDefinition ids found in filterObject. "</span> +
-               <span class="string">"Only one is supported per request."</span>);
-    }
 }
-
 
 module.exports = {
     traverseCombinator: traverseCombinator,
@@ -306,7 +276,7 @@ module.exports = {
 
     parseUdfCollectionFieldName: parseUdfCollectionFieldName,
 
-    getUdfFieldDefId: getUdfFieldDefId
+    DATETIME_FORMATS: DATETIME_FORMATS
 };</pre></div></div>
             
         </li>

--- a/docs/filtersToTables.html
+++ b/docs/filtersToTables.html
@@ -77,7 +77,7 @@
 <span class="keyword">var</span> config = require(<span class="string">'./config.json'</span>);
 <span class="keyword">var</span> utils = require(<span class="string">"./filterObjectUtils"</span>);
 
-exports = module.exports = <span class="function"><span class="keyword">function</span> <span class="params">(filterObject, displayFilters)</span> {</span>
+exports = module.exports = <span class="function"><span class="keyword">function</span> <span class="params">(filterObject, displayFilters, isPolygonRequest)</span> {</span>
     <span class="keyword">if</span> (_.isUndefined(filterObject) || _.isNull(filterObject)) {
         <span class="keyword">throw</span> <span class="keyword">new</span> Error(<span class="string">'A null or undefined filter object cannot be converted to SQL'</span>);
     }
@@ -88,10 +88,15 @@ exports = module.exports = <span class="function"><span class="keyword">function
     <span class="keyword">if</span> (models.length === <span class="number">0</span>) {
         models = [config.sqlForMapFeatures.basePointModel];
     }
-    <span class="keyword">return</span> getSqlForModels(models, utils.getUdfFieldDefId(filterObject));
+
+    <span class="keyword">if</span> (isPolygonRequest) {
+        models = _.union(models, [config.sqlForMapFeatures.basePolygonModel]);
+    }
+
+    <span class="keyword">return</span> getSqlForModels(models);
 };
 
-<span class="function"><span class="keyword">function</span> <span class="title">getSqlForModels</span><span class="params">(models, maybeUdfFieldDefId)</span> {</span>
+<span class="function"><span class="keyword">function</span> <span class="title">getSqlForModels</span><span class="params">(models)</span> {</span>
     <span class="keyword">var</span> sql = [];
     <span class="keyword">var</span> modelsAdded = [];
 
@@ -106,8 +111,6 @@ exports = module.exports = <span class="function"><span class="keyword">function
             <span class="keyword">var</span> template = config.sqlForMapFeatures.tables[model].sqlTemplate;
             <span class="keyword">if</span> (_.isUndefined(template)) {
                 sql.push(config.sqlForMapFeatures.tables[model].sql);
-            } <span class="keyword">else</span> {
-                sql.push(_.template(template)({udfFieldDefId: maybeUdfFieldDefId}));
             }
 
             modelsAdded.push(model);

--- a/docs/filtersToTables.html
+++ b/docs/filtersToTables.html
@@ -93,10 +93,10 @@ exports = module.exports = <span class="function"><span class="keyword">function
         models = _.union(models, [config.sqlForMapFeatures.basePolygonModel]);
     }
 
-    <span class="keyword">return</span> getSqlForModels(models);
+    <span class="keyword">return</span> getSqlAndModels(models);
 };
 
-<span class="function"><span class="keyword">function</span> <span class="title">getSqlForModels</span><span class="params">(models)</span> {</span>
+<span class="function"><span class="keyword">function</span> <span class="title">getSqlAndModels</span><span class="params">(models)</span> {</span>
     <span class="keyword">var</span> sql = [];
     <span class="keyword">var</span> modelsAdded = [];
 
@@ -116,7 +116,11 @@ exports = module.exports = <span class="function"><span class="keyword">function
             modelsAdded.push(model);
         }
     });
-    <span class="keyword">return</span> sql.join(<span class="string">" "</span>);
+
+    <span class="keyword">return</span> {
+        sql: sql.join(<span class="string">" "</span>),
+        models: modelsAdded
+    };
 }</pre></div></div>
             
         </li>

--- a/docs/makeSql.html
+++ b/docs/makeSql.html
@@ -99,6 +99,9 @@ Postgres requires subqueries to be named.</p>
    clause. This was created as a sidecare to filterQuery because the
    case of ANDing a plot predicate with a null tree value is
    prohibitively complicated using filterQuery syntax.</p>
+<p>Performance note: We tried using ST_SnapToGrid to reduce the number of trees rendered.
+While rendering does get faster, database queries slow down by a factor of at least five.
+That particularly hurts in production where we have just one DB server and four renderers.</p>
 
             </div>
             
@@ -124,14 +127,14 @@ directly into SQL</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="function"><span class="keyword">function</span> <span class="title">makeSqlForMapFeatures</span><span class="params">(filterString, displayString, instanceid, zoom, isUtfGridRequest)</span> {</span>
-    <span class="keyword">var</span> geom_field = makeGeomFieldSql(zoom),
+            <div class="content"><div class='highlight'><pre><span class="function"><span class="keyword">function</span> <span class="title">makeSqlForMapFeatures</span><span class="params">(filterString, displayString, instanceid, zoom, isUtfGridRequest, isPolygonRequest)</span> {</span>
+    <span class="keyword">var</span> geom_spec = config.sqlForMapFeatures.fields.geom,
+        geom_field = isPolygonRequest ? geom_spec.polygon : geom_spec.point,
         otherFields = (isUtfGridRequest ? config.sqlForMapFeatures.fields.utfGrid : config.sqlForMapFeatures.fields.base),
-        fields = geom_field + <span class="string">', '</span> + otherFields,
         filterObject = filterString ? JSON.parse(filterString) : {},
         displayFilters = displayString ? JSON.parse(displayString) : <span class="literal">undefined</span>,
 
-        tables = filtersToTables(filterObject, displayFilters),
+        tables = filtersToTables(filterObject, displayFilters, isPolygonRequest),
 
         where = <span class="string">''</span>,
         filterClause = (filterString ? filterObjectToWhere(filterObject) : <span class="literal">null</span>),
@@ -152,19 +155,7 @@ directly into SQL</p>
         where = addToWhere(instanceClause);
     }
     <span class="keyword">if</span> (where) {
-        where = <span class="string">'WHERE '</span> + where;
-    }
-
-    <span class="keyword">return</span> _.template(
-        <span class="string">'( SELECT &lt;%= fields %&gt; FROM &lt;%= tables %&gt; &lt;%= where %&gt; ) otmfiltersql '</span>
-    )({
-        fields: fields,
-        tables: tables,
-        where: where
-    });
-}
-
-<span class="function"><span class="keyword">function</span> <span class="title">makeGeomFieldSql</span><span class="params">(zoom)</span> {</span></pre></div></div>
+        where = <span class="string">'WHERE '</span> + where;</pre></div></div>
             
         </li>
         
@@ -175,20 +166,20 @@ directly into SQL</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-4">&#182;</a>
               </div>
-              <p>Performance can suffer when zoomed out with many features per pixel,
-so compute the pixel size and only select one feature per pixel.</p>
-<p>NOTE: The DISTINCT ON (the_geom_webmercator) is necessary regardles of
-the performance gains it gives us, as joining to the treephoto table
-can add multiple rows per mapfeature. If we ditch ST_SnapToGrid, make
-sure to retain the DISTINCT ON somewhere</p>
+              <p>Because some searches (e.g. on photos and udf&#39;s) join to other tables,
+add DISTINCT so we only get one row.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>    <span class="keyword">var</span> worldWidth = <span class="number">40075016.6856</span>,
-        tileSize = <span class="number">256</span>,
-        unitsPerPixel = worldWidth / (tileSize * Math.pow(<span class="number">2</span>, zoom)),
-        sql = <span class="string">'DISTINCT ON (the_geom_webmercator) ST_SnapToGrid(the_geom_webmercator, '</span> + unitsPerPixel + <span class="string">') AS the_geom_webmercator'</span>;
-    <span class="keyword">return</span> sql;
+            <div class="content"><div class='highlight'><pre>        geom_field = <span class="string">'DISTINCT('</span> + geom_field + <span class="string">') AS '</span> + config.customDbFieldNames.geom;
+    }
+    <span class="keyword">return</span> _.template(
+        <span class="string">'( SELECT &lt;%= fields %&gt; FROM &lt;%= tables %&gt; &lt;%= where %&gt; ) otmfiltersql '</span>
+    )({
+        fields: geom_field + <span class="string">', '</span> + otherFields,
+        tables: tables,
+        where: where
+    });
 }</pre></div></div>
             
         </li>

--- a/docs/makeSql.html
+++ b/docs/makeSql.html
@@ -137,21 +137,21 @@ directly into SQL</p>
         tables = filtersToTables(filterObject, displayFilters, isPolygonRequest),
 
         where = <span class="string">''</span>,
+        displayClause = displayFiltersToWhere(displayFilters, tables.models),
         filterClause = (filterString ? filterObjectToWhere(filterObject) : <span class="literal">null</span>),
-        displayClause = (displayString ? displayFiltersToWhere(displayFilters) : <span class="literal">null</span>),
         instanceClause = (instanceid ? _.template(config.sqlForMapFeatures.where.instance)({instanceid: instanceid}) : <span class="literal">null</span>);
 
     <span class="function"><span class="keyword">function</span> <span class="title">addToWhere</span><span class="params">(clause)</span> {</span>
         <span class="keyword">return</span> where ? <span class="string">'( '</span> + clause + <span class="string">' ) AND '</span> + where : clause;
     }
 
-    <span class="keyword">if</span> (filterString) {
+    <span class="keyword">if</span> (filterClause) {
         where = filterClause;
     }
-    <span class="keyword">if</span> (displayString) {
+    <span class="keyword">if</span> (displayClause) {
         where = addToWhere(displayClause);
     }
-    <span class="keyword">if</span> (instanceid) {
+    <span class="keyword">if</span> (instanceClause) {
         where = addToWhere(instanceClause);
     }
     <span class="keyword">if</span> (where) {
@@ -177,7 +177,7 @@ add DISTINCT so we only get one row.</p>
         <span class="string">'( SELECT &lt;%= fields %&gt; FROM &lt;%= tables %&gt; &lt;%= where %&gt; ) otmfiltersql '</span>
     )({
         fields: geom_field + <span class="string">', '</span> + otherFields,
-        tables: tables,
+        tables: tables.sql,
         where: where
     });
 }</pre></div></div>

--- a/docs/server.html
+++ b/docs/server.html
@@ -75,13 +75,21 @@
 
 <span class="keyword">var</span> Windshaft = require(<span class="string">'windshaft'</span>);
 <span class="keyword">var</span> _ = require(<span class="string">'underscore'</span>);
+<span class="keyword">var</span> cluster = require(<span class="string">'cluster'</span>);
+<span class="keyword">var</span> fs = require(<span class="string">'fs'</span>);
 <span class="keyword">var</span> makeSql = require(<span class="string">'./makeSql.js'</span>);
 <span class="keyword">var</span> config = require(<span class="string">'./config.json'</span>);
 <span class="keyword">var</span> settings = require(<span class="string">'./settings.json'</span>);
-<span class="keyword">var</span> cluster = require(<span class="string">'cluster'</span>);
+
 <span class="keyword">var</span> workerCount = process.env.WORKERS || require(<span class="string">'os'</span>).cpus().length;
 <span class="keyword">var</span> port = process.env.PORT || <span class="number">4000</span>;
-<span class="keyword">var</span> ws;</pre></div></div>
+<span class="keyword">var</span> ws;
+
+<span class="keyword">var</span> styles = {
+    boundary: fs.readFileSync(<span class="string">'style/boundary.mms'</span>, {encoding: <span class="string">'utf-8'</span>}),
+    mapFeature: fs.readFileSync(<span class="string">'style/mapFeature.mms'</span>, {encoding: <span class="string">'utf-8'</span>}),
+    polygonalMapFeature: fs.readFileSync(<span class="string">'style/polygonalMapFeature.mms'</span>, {encoding: <span class="string">'utf-8'</span>})
+};</pre></div></div>
             
         </li>
         
@@ -100,7 +108,7 @@ e.g. a map tile or UTF grid with map features like tree plots or boundaries.</p>
             <div class="content"><div class='highlight'><pre><span class="keyword">var</span> windshaftConfig = {
     useProfiler: <span class="literal">false</span>,  <span class="comment">// if true, returns X-Tiler-Profiler header with rendering times</span>
     enable_cors: <span class="literal">true</span>,
-    redis: {host: settings.redishost || <span class="string">'127.0.0.1'</span>, port: <span class="number">6379</span>},</pre></div></div>
+    mapnik: {</pre></div></div>
             
         </li>
         
@@ -110,6 +118,51 @@ e.g. a map tile or UTF grid with map features like tree plots or boundaries.</p>
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-3">&#182;</a>
+              </div>
+              <p>When looking for objects to render on a tile, mapnik by default adds 64 pixels
+on all sides of a tile so if e.g. a label spans two tiles
+it will be rendered on both rather than getting cut off at the boundary.
+Because we&#39;re only rendering tree dots we can reduce the buffer based on our
+biggest dot. This speeds up rendering by as much as 25%.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        bufferSize: Math.floor(config.treeMarkerMaxWidth / <span class="number">2</span>) + <span class="number">1</span>,</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-4">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-4">&#182;</a>
+              </div>
+              <p>Metatiles aren&#39;t a good fit for rendering tree dots using multiple servers and workers.
+When you request a 256x256 tile, mapnik renders by default a 1024x1024 metatile,
+and caches the resulting 16 tiles. They&#39;re aiming at basemaps, where for example
+if a road segment crosses three tiles it&#39;s more efficient to render it once
+than three times since you&#39;ll often want all 3 tiles.
+That&#39;s a bad fit for OTM for two reasons. First, our tree dots are less likely
+to span multiple tiles. Second, since metatiles aren&#39;t shared across servers
+or even across workers on the same server, our AWS tiler setup
+(currently two tile servers with two workers each) is likely to render
+each metatile multiple times, making things slower rather than faster.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        metatile: <span class="number">1</span>
+    },
+    redis: {host: settings.redishost || <span class="string">'127.0.0.1'</span>, port: <span class="number">6379</span>},</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-5">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-5">&#182;</a>
               </div>
               <p>How to access the database</p>
 
@@ -128,11 +181,11 @@ e.g. a map tile or UTF grid with map features like tree plots or boundaries.</p>
         </li>
         
         
-        <li id="section-4">
+        <li id="section-6">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-4">&#182;</a>
+                <a class="pilcrow" href="#section-6">&#182;</a>
               </div>
               <p>Parse params from the request URL</p>
 
@@ -144,27 +197,27 @@ e.g. a map tile or UTF grid with map features like tree plots or boundaries.</p>
         </li>
         
         
-        <li id="section-5">
+        <li id="section-7">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-5">&#182;</a>
+                <a class="pilcrow" href="#section-7">&#182;</a>
               </div>
               <p>Tell server how to handle HTTP request &#39;req&#39; (by specifying properties in req.params).</p>
 
             </div>
             
             <div class="content"><div class='highlight'><pre>    req2params: <span class="keyword">function</span>(req, callback) {
-        <span class="keyword">var</span> instanceid, isUtfGridRequest, table, zoom, filterString, displayString;</pre></div></div>
+        <span class="keyword">var</span> instanceid, isUtfGridRequest, isPolygonRequest, table, zoom, filterString, displayString;</pre></div></div>
             
         </li>
         
         
-        <li id="section-6">
+        <li id="section-8">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-6">&#182;</a>
+                <a class="pilcrow" href="#section-8">&#182;</a>
               </div>
               <p>Specify SQL subquery to extract desired features from desired DB layer.
 (This will be wrapped in an outer query, in many cases extracting geometry
@@ -176,7 +229,8 @@ using the magic column name &quot;the_geom_webmercator&quot;.)</p>
             instanceid = parseInt(req.query[<span class="string">'instance_id'</span>], <span class="number">10</span>);
             table = req.params.table;
             zoom = req.params.z;
-            <span class="keyword">if</span> (table === <span class="string">'treemap_mapfeature'</span>) {
+            isPolygonRequest = (table === <span class="string">'stormwater_polygonalmapfeature'</span>);
+            <span class="keyword">if</span> (table === <span class="string">'treemap_mapfeature'</span> || isPolygonRequest) {
                 filterString = req.query[config.filterQueryArgumentName];
                 displayString = req.query[config.displayQueryArgumentName];
                 isUtfGridRequest = (req.params.format === <span class="string">'grid.json'</span>);
@@ -184,9 +238,14 @@ using the magic column name &quot;the_geom_webmercator&quot;.)</p>
                                                               displayString,
                                                               instanceid,
                                                               zoom,
-                                                              isUtfGridRequest);
+                                                              isUtfGridRequest,
+                                                              isPolygonRequest);
+                req.params.style = isPolygonRequest
+                    ? styles.polygonalMapFeature
+                    : styles.mapFeature;
             } <span class="keyword">else</span> <span class="keyword">if</span> (table === <span class="string">'treemap_boundary'</span> &amp;&amp; instanceid) {
                 req.query.sql = makeSql.makeSqlForBoundaries(instanceid);
+                req.params.style = styles.boundary;
             }
         } <span class="keyword">catch</span> (err) {
             callback(err, <span class="literal">null</span>);
@@ -195,11 +254,11 @@ using the magic column name &quot;the_geom_webmercator&quot;.)</p>
         </li>
         
         
-        <li id="section-7">
+        <li id="section-9">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-7">&#182;</a>
+                <a class="pilcrow" href="#section-9">&#182;</a>
               </div>
               <p>A UTF grid request returns map feature data for each pixel in a tile,
 streamlining client actions like clicking on or hovering over a feature.
@@ -212,11 +271,11 @@ streamlining client actions like clicking on or hovering over a feature.
         </li>
         
         
-        <li id="section-8">
+        <li id="section-10">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-8">&#182;</a>
+                <a class="pilcrow" href="#section-10">&#182;</a>
               </div>
               <p>Override request params with query params
 Note that we <em>always</em> overwrite req.query.sql above</p>
@@ -229,11 +288,11 @@ Note that we <em>always</em> overwrite req.query.sql above</p>
         </li>
         
         
-        <li id="section-9">
+        <li id="section-11">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-9">&#182;</a>
+                <a class="pilcrow" href="#section-11">&#182;</a>
               </div>
               <p>Send the finished req object on</p>
 
@@ -248,9 +307,23 @@ Note that we <em>always</em> overwrite req.query.sql above</p>
         console.log(headers);
         callback(<span class="literal">null</span>, tile, headers);
     }
-};
+};</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-12">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-12">&#182;</a>
+              </div>
+              <p>The global v8debug will be present if this is started via:
+ &#39;node debug&#39;, node-debug&#39; or &#39;node --debug-brk&#39; (but not &#39;node --debug&#39; !?!)</p>
 
-<span class="keyword">if</span> (cluster.isMaster) {
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="keyword">if</span> (cluster.isMaster &amp;&amp; <span class="keyword">typeof</span> v8debug !== <span class="string">'object'</span>) {
     console.log(<span class="string">"Map tiles will be served from http://localhost:"</span> + port + windshaftConfig.base_url + <span class="string">'/:zoom/:x/:y'</span>);
 
     console.log(<span class="string">'Creating '</span> + workerCount + <span class="string">' workers.'</span>);

--- a/filtersToTables.js
+++ b/filtersToTables.js
@@ -20,10 +20,10 @@ exports = module.exports = function (filterObject, displayFilters, isPolygonRequ
         models = _.union(models, [config.sqlForMapFeatures.basePolygonModel]);
     }
 
-    return getSqlForModels(models);
+    return getSqlAndModels(models);
 };
 
-function getSqlForModels(models) {
+function getSqlAndModels(models) {
     var sql = [];
     var modelsAdded = [];
 
@@ -43,7 +43,11 @@ function getSqlForModels(models) {
             modelsAdded.push(model);
         }
     });
-    return sql.join(" ");
+
+    return {
+        sql: sql.join(" "),
+        models: modelsAdded
+    };
 }
 
 // `getModelsForFilterObject` looks at a nested filterObject with

--- a/makeSql.js
+++ b/makeSql.js
@@ -65,7 +65,7 @@ function makeSqlForMapFeatures(filterString, displayString, instanceid, zoom, is
         where = 'WHERE ' + where;
         // Because some searches (e.g. on photos and udf's) join to other tables,
         // add DISTINCT so we only get one row.
-        geom_field = 'DISTINCT(' + geom_field + ') AS ' + config.customDbFieldNames.geom
+        geom_field = 'DISTINCT(' + geom_field + ') AS ' + config.customDbFieldNames.geom;
     }
     return _.template(
         '( SELECT <%= fields %> FROM <%= tables %> <%= where %> ) otmfiltersql '

--- a/makeSql.js
+++ b/makeSql.js
@@ -44,21 +44,21 @@ function makeSqlForMapFeatures(filterString, displayString, instanceid, zoom, is
         tables = filtersToTables(filterObject, displayFilters, isPolygonRequest),
 
         where = '',
+        displayClause = displayFiltersToWhere(displayFilters, tables.models),
         filterClause = (filterString ? filterObjectToWhere(filterObject) : null),
-        displayClause = (displayString ? displayFiltersToWhere(displayFilters) : null),
         instanceClause = (instanceid ? _.template(config.sqlForMapFeatures.where.instance)({instanceid: instanceid}) : null);
 
     function addToWhere(clause) {
         return where ? '( ' + clause + ' ) AND ' + where : clause;
     }
 
-    if (filterString) {
+    if (filterClause) {
         where = filterClause;
     }
-    if (displayString) {
+    if (displayClause) {
         where = addToWhere(displayClause);
     }
-    if (instanceid) {
+    if (instanceClause) {
         where = addToWhere(instanceClause);
     }
     if (where) {
@@ -71,7 +71,7 @@ function makeSqlForMapFeatures(filterString, displayString, instanceid, zoom, is
         '( SELECT <%= fields %> FROM <%= tables %> <%= where %> ) otmfiltersql '
     )({
         fields: geom_field + ', ' + otherFields,
-        tables: tables,
+        tables: tables.sql,
         where: where
     });
 }

--- a/test/testDisplayFiltersToWhere.js
+++ b/test/testDisplayFiltersToWhere.js
@@ -3,24 +3,43 @@
 var assert = require("assert");
 var displayFiltersToWhere = require("../displayFiltersToWhere");
 
-var assertSql = function(list, expectedSql) {
-    var result = displayFiltersToWhere(list);
+var assertSqlForModels = function(list, models, expectedSql) {
+    var result = displayFiltersToWhere(list, models);
     assert.equal(result, expectedSql);
+};
+
+var assertSql = function(list, expectedSql) {
+    assertSqlForModels(list, ['mapFeature'], expectedSql);
 };
 
 describe('displayFiltersToWhere', function() {
 
     // NULL AND EMPTY HANDLING
-    it('raises an error when passed undefined', function() {
+    it('raises an error when passed a non-empty array for models', function() {
         assert.throws(function() {
-            displayFiltersToWhere(undefined);
+            displayFiltersToWhere(null, null);
+        }, Error);
+
+        assert.throws(function() {
+            displayFiltersToWhere(['Tree'], undefined);
+        }, Error);
+
+        assert.throws(function() {
+            displayFiltersToWhere(['Tree'], 2);
+        }, Error);
+
+        assert.throws(function() {
+            displayFiltersToWhere(['Tree'], []);
         }, Error);
     });
 
-    it('raises an error when passed null', function() {
-        assert.throws(function() {
-            displayFiltersToWhere(null);
-        }, Error);
+    it('returns null when passed null or undefined for displayList w/ no tree models', function() {
+        assertSqlForModels(null, ['mapFeature']);
+    });
+
+    // MODEL LIST HANDLING
+    it('returns an IN clause for only Plots when tree is in the model filter', function() {
+        assertSqlForModels(null, ['tree'], '"treemap_mapfeature"."feature_type" IN ( \'Plot\' )');
     });
 
     // EMPTY LIST HANDLING


### PR DESCRIPTION
Empty plots can still show up when searching for a tree field, like when
doing a missing species search, but non-plot map features (such as bioswales) will be excluded.

Connects to OpenTreeMap/otm-core#2090