### PR TITLE
Left join polygonal feature table so all dots show

### DIFF
--- a/config.json
+++ b/config.json
@@ -20,7 +20,7 @@
             },
             "polygonalMapFeature": {
                 "depends": ["mapFeature"],
-                "sql": "INNER JOIN stormwater_polygonalmapfeature ON stormwater_polygonalmapfeature.mapfeature_ptr_id = treemap_mapfeature.id"
+                "sql": "LEFT OUTER JOIN stormwater_polygonalmapfeature ON stormwater_polygonalmapfeature.mapfeature_ptr_id = treemap_mapfeature.id"
             },
             "tree": {
                 "depends": ["mapFeature"],


### PR DESCRIPTION
In 255def89 we added the ability to render polygonal map features, but using an inner join to link the stormwater_polygonalmapfeature table meant that Plot map features were being filtered out of the query results.

Test by adding a tree to a map to ensure the georev is incremented and then confirming that plot dots are rendered at zoom levels >= 15.

Connects to #73 