### PR TITLE
Only hide non-plot models when tree filter active

### DIFF
--- a/displayFiltersToWhere.js
+++ b/displayFiltersToWhere.js
@@ -5,16 +5,14 @@ var _ = require('underscore'),
     utils = require('./filterObjectUtils'),
     config = require('./config.json');
 
-module.exports = function(displayFilters, models) {
+module.exports = function(displayFilters, displayPlotsOnly) {
     var featureTypes, inClause;
 
-    if ( ! _.isArray(models) || models.length === 0) {
-        throw new Error('The models list must be a non-empty array.');
+    if ( ! _.isBoolean(displayPlotsOnly)) {
+        throw new Error('`displayPlotsOnly must be a boolean value.');
     }
 
-    // If there are trees referenced in the models list, narrow the display
-    // filters to only tree display filters.
-    if (_.contains(models, 'tree')) {
+    if (displayPlotsOnly) {
         if (_.isArray(displayFilters) && displayFilters.length > 0) {
             displayFilters = _.intersection(displayFilters, ['Tree', 'Plot', 'EmptyPlot']);
         } else {

--- a/filterObjectUtils.js
+++ b/filterObjectUtils.js
@@ -94,8 +94,22 @@ function parseUdfCollectionFieldName (fieldName) {
     };
 }
 
+function filterObjectKeys(fObj) {
+    var keys = [];
+    if (_.isArray(fObj)) {
+        traverseCombinator(fObj, function (nestedfObj) {
+            keys = keys.concat(filterObjectKeys(nestedfObj));
+        });
+    } else {
+        _.each(fObj, function(__, key) { keys.push(key); });
+    }
+    return keys;
+}
+
 module.exports = {
     traverseCombinator: traverseCombinator,
+
+    filterObjectKeys: filterObjectKeys,
 
     isTreeInDisplayFilters: isTreeInDisplayFilters,
 

--- a/filtersToTables.js
+++ b/filtersToTables.js
@@ -54,27 +54,19 @@ function getSqlAndModels(models) {
 // clauses and produces a flat list of models to use in FROM/JOIN
 // clauses.
 function getModelsForFilterObject(object) {
-    var models = [];
-    if (_.isArray(object)) {
-        utils.traverseCombinator(object, function(filter) {
-            models = models.concat(getModelsForFilterObject(filter));
-        });
-    } else if (_.isObject(object) && _.size(object) > 0) {
-        _.each(object, function(predicate, fieldName) {
-            var model;
-            if (fieldName.indexOf('udf:') === 0) {
-                model = utils.parseUdfCollectionFieldName(fieldName).modelName;
-            } else {
-                model = fieldName.split('.')[0];
-            }
-            if (!config.modelMapping[model]) {
-                throw new Error('The model name must be one of the following: ' +
-                        Object.keys(config.modelMapping).join(', ') + '. Not ' + model);
-            }
-            models.push(model);
-        });
+    function fieldNameToModel(fieldName) {
+        var model;
+        if (fieldName.indexOf('udf:') === 0) {
+            model = utils.parseUdfCollectionFieldName(fieldName).modelName;
+        } else {
+            model = fieldName.split('.')[0];
+        }
+        if (!config.modelMapping[model]) {
+            throw new Error('The model name must be one of the following: ' +
+                            Object.keys(config.modelMapping).join(', ') + '. Not ' + model);
+        }
+        return model;
     }
-
-    return _.uniq(models);
+    return _.uniq(_.map(utils.filterObjectKeys(object), fieldNameToModel));
 }
 

--- a/makeSql.js
+++ b/makeSql.js
@@ -30,6 +30,7 @@ var displayFiltersToWhere = require('./displayFiltersToWhere');
 var filtersToTables = require('./filtersToTables');
 var addDefaultsToFilter = require('./addDefaultsToFilter');
 var config = require('./config.json');
+var utils = require('./filterObjectUtils');
 
 
 // Create a SQL query to return info about map features.
@@ -47,7 +48,7 @@ function makeSqlForMapFeatures(filterString, displayString, instanceid, zoom, is
         tables = filtersToTables(filterObject, displayFilters, isPolygonRequest),
 
         where = '',
-        displayClause = displayFiltersToWhere(displayFilters, tables.models),
+        displayClause = displayFiltersToWhere(displayFilters, displayPlotsOnly(filterObject)),
         filterClause = filterObjectToWhere(filterObject),
         instanceClause = (instanceid ? _.template(config.sqlForMapFeatures.where.instance)({instanceid: instanceid}) : null);
 
@@ -77,6 +78,14 @@ function makeSqlForMapFeatures(filterString, displayString, instanceid, zoom, is
         tables: tables.sql,
         where: where
     });
+}
+
+// If there are trees referenced in the filter object, narrow the
+// display filters to only tree display filters.
+function displayPlotsOnly(filterObject) {
+    var isTreeFilterObject = function(s) {return s.substring(0, 4) === 'tree'; };
+    var treeKeys = _.filter(utils.filterObjectKeys(filterObject), isTreeFilterObject);
+    return treeKeys.length > 0;
 }
 
 // Create a SQL query to return info about boundaries.

--- a/test/testDisplayFiltersToWhere.js
+++ b/test/testDisplayFiltersToWhere.js
@@ -3,19 +3,19 @@
 var assert = require("assert");
 var displayFiltersToWhere = require("../displayFiltersToWhere");
 
-var assertSqlForModels = function(list, models, expectedSql) {
-    var result = displayFiltersToWhere(list, models);
+var assertSqlForModels = function(list, displayPlotsOnly, expectedSql) {
+    var result = displayFiltersToWhere(list, displayPlotsOnly);
     assert.equal(result, expectedSql);
 };
 
 var assertSql = function(list, expectedSql) {
-    assertSqlForModels(list, ['mapFeature'], expectedSql);
+    assertSqlForModels(list, false, expectedSql);
 };
 
 describe('displayFiltersToWhere', function() {
 
     // NULL AND EMPTY HANDLING
-    it('raises an error when passed a non-empty array for models', function() {
+    it('raises an error when passed a non-boolean for displayPlotsOnly', function() {
         assert.throws(function() {
             displayFiltersToWhere(null, null);
         }, Error);
@@ -33,13 +33,17 @@ describe('displayFiltersToWhere', function() {
         }, Error);
     });
 
-    it('returns null when passed null or undefined for displayList w/ no tree models', function() {
-        assertSqlForModels(null, ['mapFeature']);
+    it('returns null when passed null and not instructed to show only plots', function() {
+        assertSqlForModels(null, false, null);
+    });
+
+    it('returns null when passed undefined and not instructed to show only plots', function() {
+        assertSqlForModels(undefined, false, null);
     });
 
     // MODEL LIST HANDLING
-    it('returns an IN clause for only Plots when tree is in the model filter', function() {
-        assertSqlForModels(null, ['tree'], '"treemap_mapfeature"."feature_type" IN ( \'Plot\' )');
+    it('returns an IN clause for only Plots when instructed to show only plots', function() {
+        assertSqlForModels(null, true, '"treemap_mapfeature"."feature_type" IN ( \'Plot\' )');
     });
 
     // EMPTY LIST HANDLING
@@ -62,8 +66,13 @@ describe('displayFiltersToWhere', function() {
                 ' OR ("treemap_mapfeature"."feature_type" = \'FireHydrant\')');
     });
 
+    it('returns IN clause for all non-plot models', function() {
+        assertSql(['FireHydrant'],
+                  '"treemap_mapfeature"."feature_type" IN ( \'FireHydrant\' )');
+    });
+
     // MapFeature HANDLING
-    it('returns IN cluase for all non-tree models', function() {
+    it('returns IN clause for all non-tree models', function() {
         assertSql(['FireHydrant', 'Plot'], '"treemap_mapfeature"."feature_type" IN ( \'FireHydrant\', \'Plot\' )');
     });
 });

--- a/test/testMakeSql.js
+++ b/test/testMakeSql.js
@@ -9,11 +9,15 @@ describe('testSqlForMapFeatures', function() {
     var filterString = '{"tree.id":{"IS":"1"}}';
 
     function assertSqlContains(options) {
-        assert.ok(testSql(options) > -1);
+        assert.ok(testSql(options).indexOf(options.expected) > -1);
     }
 
     function assertSqlLacks(options) {
-        assert.ok(testSql(options) === -1);
+        assert.ok(testSql(options).indexOf(options.expected) === -1);
+    }
+
+    function assertSqlEqual(options) {
+        assert.equal(testSql(options), options.expected);
     }
 
     function testSql(options) {
@@ -25,7 +29,7 @@ describe('testSqlForMapFeatures', function() {
                 zoom,
                 options.isUtfGridRequest,
                 options.isPolygonRequest);
-        return sql.indexOf(options.expected);
+        return sql;
     }
 
     // Fields
@@ -122,4 +126,40 @@ describe('testSqlForMapFeatures', function() {
         });
     });
 
+
+    it('disregards non-tree models when a simple tree filter is active', function() {
+        assertSqlEqual({
+            isPolygonRequest: true,
+            displayFilter: '["Tree", "FireHydrant"]',
+            filter: '{"tree.diameter":{"MIN":1,"MAX":100}}',
+            expected: '( SELECT DISTINCT(stormwater_polygonalmapfeature.polygon) AS the_geom_webmercator, ' +
+                'feature_type FROM treemap_mapfeature LEFT OUTER JOIN treemap_tree ON ' +
+                'treemap_mapfeature.id = treemap_tree.plot_id ' +
+                'LEFT OUTER JOIN stormwater_polygonalmapfeature ' +
+                'ON stormwater_polygonalmapfeature.mapfeature_ptr_id = treemap_mapfeature.id ' +
+                'WHERE ( (("treemap_tree"."id" IS NOT NULL) AND ("treemap_mapfeature"."feature_type" = \'Plot\')) ) ' +
+                'AND ("treemap_tree"."diameter" >= 1 ' +
+                'AND "treemap_tree"."diameter" <= 100) ' +
+                ') otmfiltersql '
+        });
+    });
+
+    it('disregards non-tree models when a complex tree filter is active', function() {
+        assertSqlEqual({
+            isPolygonRequest: true,
+            displayFilter: '["Tree", "FireHydrant"]',
+            filter: '["AND",{"tree.diameter":{"MIN":1,"MAX":100}},["OR",{"udf:tree:198.Status":{"IS":"Unresolved"}}]]',
+            expected: '( SELECT DISTINCT(stormwater_polygonalmapfeature.polygon) AS the_geom_webmercator, ' +
+                'feature_type FROM treemap_mapfeature LEFT OUTER JOIN treemap_tree ON ' +
+                'treemap_mapfeature.id = treemap_tree.plot_id CROSS JOIN treemap_userdefinedcollectionvalue  ' +
+                'LEFT OUTER JOIN stormwater_polygonalmapfeature ' +
+                'ON stormwater_polygonalmapfeature.mapfeature_ptr_id = treemap_mapfeature.id ' +
+                'WHERE ( (("treemap_tree"."id" IS NOT NULL) AND ("treemap_mapfeature"."feature_type" = \'Plot\')) ) ' +
+                'AND (("treemap_tree"."diameter" >= 1 ' +
+                'AND "treemap_tree"."diameter" <= 100) ' +
+                'AND (("treemap_userdefinedcollectionvalue"."data"->\'Status\' = \'Unresolved\' ' +
+                'AND treemap_userdefinedcollectionvalue.field_definition_id=198 ' +
+                'AND treemap_userdefinedcollectionvalue.model_id=treemap_tree.id))) ) otmfiltersql '
+        });
+    });
 });


### PR DESCRIPTION
connects #75 on github

previously we were hiding non plot/tree models any time a tree was
included in the model list, or, in other words, whenever the specifity
of the search went past the underlying MapFeature.

The problem manifests on the client when 'unchecking' EmptyPlot for visibility we add a
show filter for 'Tree' and whatever other models should be shown. This
would trigger the condition to only show trees, making all other models
be hidden along with EmptyPlots.

The purpose for this original design decision was to account for the case when a
user enters some tree details to search by, but doesn't see the
checkboxes to hide other models and is confused by the results. They
probably just want to see tree results, so we do that for them. In order
to preserve this behavior, we gate specifically on whether a tree filter
was included, rather than looking at the display models.