### PR TITLE
Refactor collection UDF searching

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
     "filterQueryArgumentName": "q",
     "displayQueryArgumentName": "show",
     "scalar_udf_field": "udfs",
@@ -78,4 +78,4 @@
         "udf:bioswale": "treemap_userdefinedcollectionvalue.field_definition_id=<%= fieldDefId %> AND treemap_userdefinedcollectionvalue.model_id=treemap_mapfeature.id"
     },
     "treeMarkerMaxWidth": 20
-}
+};

--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 module.exports = {
     "filterQueryArgumentName": "q",
     "displayQueryArgumentName": "show",
+    // This is the column name of the hstore column used for scalar udfs
     "scalar_udf_field": "udfs",
     "sqlForMapFeatures": {
         "fields": {
@@ -13,6 +14,8 @@ module.exports = {
         },
         "basePointModel": "mapFeature",
         "basePolygonModel": "polygonalMapFeature",
+        // The tables object gets walked by filtersToTables to build the FROM and JOIN clauses of the SQL string.
+        // The "depends" property of each item should include any tables used in the "sql" property to JOIN to that table
         "tables": {
             "mapFeature": {
                 "depends": [],
@@ -35,20 +38,11 @@ module.exports = {
                 "sql": "LEFT OUTER JOIN treemap_mapfeaturephoto ON treemap_mapfeature.id = treemap_mapfeaturephoto.map_feature_id"
             },
             "udf": {
-                "depends": [],
+                // Despite mapFeature not being referenced in the "sql" property it will
+                // be used in the filter for udf and so it is required
+                "depends": ["mapFeature"],
+                // udf uses a CROSS JOIN, but in filterObjectToWhere a restrictive WHERE clause is added
                 "sql": "CROSS JOIN treemap_userdefinedcollectionvalue"
-            },
-            "udf:tree": {
-                "depends": ["mapFeature", "tree", "udf"],
-                "sql": ""
-            },
-            "udf:plot": {
-                "depends": ["mapFeature", "udf"],
-                "sql": ""
-            },
-            "udf:bioswale": {
-                "depends": ["mapFeature", "udf"],
-                "sql": ""
             }
         },
         "where": {
@@ -68,14 +62,11 @@ module.exports = {
         "tree": "treemap_tree",
         "species": "treemap_species",
         "mapFeaturePhoto": "treemap_mapfeaturephoto",
-        "udf:tree": "treemap_userdefinedcollectionvalue",
-        "udf:plot": "treemap_userdefinedcollectionvalue",
-        "udf:bioswale": "treemap_userdefinedcollectionvalue"
+        "udf": "treemap_userdefinedcollectionvalue"
     },
     "udfcTemplates": {
-        "udf:tree": "treemap_userdefinedcollectionvalue.field_definition_id=<%= fieldDefId %> AND treemap_userdefinedcollectionvalue.model_id=treemap_tree.id",
-        "udf:plot": "treemap_userdefinedcollectionvalue.field_definition_id=<%= fieldDefId %> AND treemap_userdefinedcollectionvalue.model_id=treemap_mapfeature.id",
-        "udf:bioswale": "treemap_userdefinedcollectionvalue.field_definition_id=<%= fieldDefId %> AND treemap_userdefinedcollectionvalue.model_id=treemap_mapfeature.id"
+        "tree": "treemap_userdefinedcollectionvalue.field_definition_id=<%= fieldDefId %> AND treemap_userdefinedcollectionvalue.model_id=treemap_tree.id",
+        "mapFeature": "treemap_userdefinedcollectionvalue.field_definition_id=<%= fieldDefId %> AND treemap_userdefinedcollectionvalue.model_id=treemap_mapfeature.id",
     },
     "treeMarkerMaxWidth": 20
 };

--- a/displayFiltersToWhere.js
+++ b/displayFiltersToWhere.js
@@ -3,7 +3,7 @@
 var _ = require('underscore'),
     format = require('util').format,
     utils = require('./filterObjectUtils'),
-    config = require('./config.json');
+    config = require('./config');
 
 module.exports = function(displayFilters, displayPlotsOnly) {
     var featureTypes, inClause;

--- a/filterObjectToWhere.js
+++ b/filterObjectToWhere.js
@@ -24,7 +24,7 @@
 //                    | [combinator, filter*]
 
 var _ = require('underscore'),
-    config = require('./config.json'),
+    config = require('./config'),
     utils = require('./filterObjectUtils'),
     format = require('util').format;
 

--- a/filterObjectUtils.js
+++ b/filterObjectUtils.js
@@ -88,7 +88,7 @@ function parseUdfCollectionFieldName (fieldName) {
     fieldDefIdAndHStoreMember = tokens[2].split('.');
 
     return {
-        modelName: 'udf:' + tokens[1],
+        modelName: tokens[1],
         fieldDefId: fieldDefIdAndHStoreMember[0],
         hStoreMember: fieldDefIdAndHStoreMember[1]
     };

--- a/filterObjectUtils.js
+++ b/filterObjectUtils.js
@@ -2,7 +2,7 @@
 
 var _ = require('underscore');
 var moment = require('moment');
-var config = require('./config.json');
+var config = require('./config');
 
 // The `DATETIME_FORMATS` dictionary contains constant strings used to validate
 // and format date and datetime strings.

--- a/filtersToTables.js
+++ b/filtersToTables.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _ = require('underscore');
-var config = require('./config.json');
+var config = require('./config');
 var utils = require("./filterObjectUtils");
 
 exports = module.exports = function (filterObject, displayFilters, isPolygonRequest) {

--- a/filtersToTables.js
+++ b/filtersToTables.js
@@ -58,15 +58,20 @@ function getModelsForFilterObject(object) {
         var model;
         if (fieldName.indexOf('udf:') === 0) {
             model = utils.parseUdfCollectionFieldName(fieldName).modelName;
-        } else {
-            model = fieldName.split('.')[0];
+            if (model === "tree") {
+                return ["tree", "udf"];
+            }
+            return ["udf"];
         }
+
+        model = fieldName.split('.')[0];
+
         if (!config.modelMapping[model]) {
             throw new Error('The model name must be one of the following: ' +
                             Object.keys(config.modelMapping).join(', ') + '. Not ' + model);
         }
-        return model;
+        return [model];
     }
-    return _.uniq(_.map(utils.filterObjectKeys(object), fieldNameToModel));
+    return _.uniq(_.flatten(_.map(utils.filterObjectKeys(object), fieldNameToModel)));
 }
 

--- a/makeSql.js
+++ b/makeSql.js
@@ -29,7 +29,7 @@ var filterObjectToWhere = require('./filterObjectToWhere');
 var displayFiltersToWhere = require('./displayFiltersToWhere');
 var filtersToTables = require('./filtersToTables');
 var addDefaultsToFilter = require('./addDefaultsToFilter');
-var config = require('./config.json');
+var config = require('./config');
 var utils = require('./filterObjectUtils');
 
 

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ var _ = require('underscore');
 var cluster = require('cluster');
 var fs = require('fs');
 var makeSql = require('./makeSql.js');
-var config = require('./config.json');
+var config = require('./config');
 var settings = require('./settings.json');
 
 var workerCount = process.env.WORKERS || require('os').cpus().length;

--- a/test/testFilterObjectUtils.js
+++ b/test/testFilterObjectUtils.js
@@ -10,7 +10,7 @@ function udfForJSON (json) {
 describe('testParseUdfCollectionFieldName', function() {
     it('returns the correct parsed object for udfc keys', function () {
         var results = utils.parseUdfCollectionFieldName('udf:plot:18.Action');
-        assert.equal(results.modelName, 'udf:plot');
+        assert.equal(results.modelName, 'plot');
         assert.equal(results.fieldDefId, '18');
         assert.equal(results.hStoreMember, 'Action');
     });

--- a/test/testFiltersToTables.js
+++ b/test/testFiltersToTables.js
@@ -2,7 +2,7 @@
 
 var assert = require("assert");
 var filtersToTables = require("../filtersToTables");
-var config = require("../config.json");
+var config = require("../config");
 
 var assertSql = function(filter, displayFilters, expectedSql) {
     var tables = filtersToTables(filter, displayFilters);

--- a/test/testFiltersToTables.js
+++ b/test/testFiltersToTables.js
@@ -63,21 +63,21 @@ describe('filtersToTables', function() {
     it('returns udfd/udcv and tree/plot joins for udf tree filter objects', function () {
         var expectedSql = "treemap_mapfeature LEFT OUTER JOIN treemap_tree " +
                 "ON treemap_mapfeature.id = treemap_tree.plot_id " +
-                "CROSS JOIN treemap_userdefinedcollectionvalue ";
+                "CROSS JOIN treemap_userdefinedcollectionvalue";
         assertSql({"udf:tree:18.Action": {"LIKE": "%Watering%"}}, undefined, expectedSql);
     });
 
     it('returns udfd/udcv and joins for udf mapfeature filter objects', function () {
         var expectedSql =
-                "treemap_mapfeature CROSS JOIN treemap_userdefinedcollectionvalue ";
+                "treemap_mapfeature CROSS JOIN treemap_userdefinedcollectionvalue";
         assertSql({"udf:plot:18.Action": {"LIKE": "%Watering%"}}, undefined, expectedSql);
     });
 
     it('returns udfd/udcv and joins to tree and mapfeature for udf tree and mapfeature filter objects', function () {
         var expectedSql =
-                "treemap_mapfeature" +
-                " CROSS JOIN treemap_userdefinedcollectionvalue " +
-                " LEFT OUTER JOIN treemap_tree ON treemap_mapfeature.id = treemap_tree.plot_id ";
+                "treemap_mapfeature " +
+                "CROSS JOIN treemap_userdefinedcollectionvalue " +
+                "LEFT OUTER JOIN treemap_tree ON treemap_mapfeature.id = treemap_tree.plot_id";
         assertSql(["OR", {"udf:plot:18.Action": {"LIKE": "%Watering%"}},
                          {"udf:tree:17.Action": {"LIKE": "%Burning%"}}], undefined, expectedSql);
     });

--- a/test/testMakeSql.js
+++ b/test/testMakeSql.js
@@ -4,7 +4,7 @@ var assert = require("assert");
 var makeSql = require("../makeSql");
 var config = require("../config");
 
-describe('testSqlForMapFeatures', function() {
+describe('makeSql', function() {
 
     var filterString = '{"tree.id":{"IS":"1"}}';
 
@@ -151,7 +151,7 @@ describe('testSqlForMapFeatures', function() {
             filter: '["AND",{"tree.diameter":{"MIN":1,"MAX":100}},["OR",{"udf:tree:198.Status":{"IS":"Unresolved"}}]]',
             expected: '( SELECT DISTINCT(stormwater_polygonalmapfeature.polygon) AS the_geom_webmercator, ' +
                 'feature_type FROM treemap_mapfeature LEFT OUTER JOIN treemap_tree ON ' +
-                'treemap_mapfeature.id = treemap_tree.plot_id CROSS JOIN treemap_userdefinedcollectionvalue  ' +
+                'treemap_mapfeature.id = treemap_tree.plot_id CROSS JOIN treemap_userdefinedcollectionvalue ' +
                 'LEFT OUTER JOIN stormwater_polygonalmapfeature ' +
                 'ON stormwater_polygonalmapfeature.mapfeature_ptr_id = treemap_mapfeature.id ' +
                 'WHERE ( (("treemap_tree"."id" IS NOT NULL) AND ("treemap_mapfeature"."feature_type" = \'Plot\')) ) ' +

--- a/test/testMakeSql.js
+++ b/test/testMakeSql.js
@@ -2,7 +2,7 @@
 
 var assert = require("assert");
 var makeSql = require("../makeSql");
-var config = require("../config.json");
+var config = require("../config");
 
 describe('testSqlForMapFeatures', function() {
 


### PR DESCRIPTION
Our previous strategy for handling collection UDF searches required adding
several items to our config whenever we added another model that could
support collection UDFs, which was getting unwieldy.

This refactor should allow searching collection UDFs for any model without
having to alter the tiler code in the future when we add more models.

Connects to OpenTreeMap/otm-core#2254