### PR TITLE
Add support for restrict clause in where filter

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 module.exports = {
     "filterQueryArgumentName": "q",
     "displayQueryArgumentName": "show",
+    "restrictFeatureQueryArgumentName": "restrict",
     // This is the column name of the hstore column used for scalar udfs
     "scalar_udf_field": "udfs",
     "sqlForMapFeatures": {

--- a/displayFiltersToWhere.js
+++ b/displayFiltersToWhere.js
@@ -5,8 +5,10 @@ var _ = require('underscore'),
     utils = require('./filterObjectUtils'),
     config = require('./config');
 
-module.exports = function(displayFilters, displayPlotsOnly) {
-    var featureTypes, inClause;
+module.exports = function(displayFilters, restrictFeatureFilters, displayPlotsOnly) {
+    var featureTypes, inClause,
+        plotFilters = ['Tree', 'Plot', 'EmptyPlot'],
+        defaultPlotFilter = ['Plot'];
 
     if ( ! _.isBoolean(displayPlotsOnly)) {
         throw new Error('`displayPlotsOnly must be a boolean value.');
@@ -14,10 +16,18 @@ module.exports = function(displayFilters, displayPlotsOnly) {
 
     if (displayPlotsOnly) {
         if (_.isArray(displayFilters) && displayFilters.length > 0) {
-            displayFilters = _.intersection(displayFilters, ['Tree', 'Plot', 'EmptyPlot']);
+            displayFilters = _.intersection(displayFilters, plotFilters);
         } else {
-            displayFilters = ['Plot'];
+            displayFilters = defaultPlotFilter;
         }
+    }
+
+    if (_.isArray(displayFilters)) {
+        displayFilters = _.intersection(
+            displayFilters,
+            _.union(restrictFeatureFilters || [], plotFilters));
+    } else {
+        displayFilters = _.union(restrictFeatureFilters || [], defaultPlotFilter);
     }
 
     // If there are still no display filters (none from query args, and we're

--- a/displayFiltersToWhere.js
+++ b/displayFiltersToWhere.js
@@ -30,15 +30,6 @@ module.exports = function(displayFilters, restrictFeatureFilters, displayPlotsOn
         displayFilters = _.union(restrictFeatureFilters || [], defaultPlotFilter);
     }
 
-    // If there are still no display filters (none from query args, and we're
-    // not filtering trees), return `null` to indicate that there is no SQL generated
-    if (_.isUndefined(displayFilters) || _.isNull(displayFilters)) {
-        return null;
-    }
-
-    if ( ! _.isArray(displayFilters)) {
-        throw new Error('The display filter list must be a list to be converted to SQL');
-    }
     if (_.isEmpty(displayFilters)) {
         // With empty display filters, nothing should ever be shown
         // 'WHERE FALSE' should override any other filters

--- a/docs/addDefaultsToFilter.html
+++ b/docs/addDefaultsToFilter.html
@@ -24,6 +24,11 @@
               </a>
             
               
+              <a class="source" href="config.html">
+                config.js
+              </a>
+            
+              
               <a class="source" href="displayFiltersToWhere.html">
                 displayFiltersToWhere.js
               </a>

--- a/docs/config.html
+++ b/docs/config.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+  <title>config.js</title>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+  <link rel="stylesheet" media="all" href="docco.css" />
+</head>
+<body>
+  <div id="container">
+    <div id="background"></div>
+    
+      <ul id="jump_to">
+        <li>
+          <a class="large" href="javascript:void(0);">Jump To &hellip;</a>
+          <a class="small" href="javascript:void(0);">+</a>
+          <div id="jump_wrapper">
+          <div id="jump_page">
+            
+              
+              <a class="source" href="addDefaultsToFilter.html">
+                addDefaultsToFilter.js
+              </a>
+            
+              
+              <a class="source" href="config.html">
+                config.js
+              </a>
+            
+              
+              <a class="source" href="displayFiltersToWhere.html">
+                displayFiltersToWhere.js
+              </a>
+            
+              
+              <a class="source" href="filterObjectToWhere.html">
+                filterObjectToWhere.js
+              </a>
+            
+              
+              <a class="source" href="filterObjectUtils.html">
+                filterObjectUtils.js
+              </a>
+            
+              
+              <a class="source" href="filtersToTables.html">
+                filtersToTables.js
+              </a>
+            
+              
+              <a class="source" href="makeSql.html">
+                makeSql.js
+              </a>
+            
+              
+              <a class="source" href="server.html">
+                server.js
+              </a>
+            
+          </div>
+        </li>
+      </ul>
+    
+    <ul class="sections">
+        
+          <li id="title">
+              <div class="annotation">
+                  <h1>config.js</h1>
+              </div>
+          </li>
+        
+        
+        
+        <li id="section-1">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-1">&#182;</a>
+              </div>
+              
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>module.exports = {
+    <span class="string">"filterQueryArgumentName"</span>: <span class="string">"q"</span>,
+    <span class="string">"displayQueryArgumentName"</span>: <span class="string">"show"</span>,
+    <span class="string">"restrictFeatureQueryArgumentName"</span>: <span class="string">"restrict"</span>,</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-2">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-2">&#182;</a>
+              </div>
+              <p>This is the column name of the hstore column used for scalar udfs</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="string">"scalar_udf_field"</span>: <span class="string">"udfs"</span>,
+    <span class="string">"sqlForMapFeatures"</span>: {
+        <span class="string">"fields"</span>: {
+            <span class="string">"geom"</span>: {
+                <span class="string">"point"</span>: <span class="string">"the_geom_webmercator"</span>,
+                <span class="string">"polygon"</span>: <span class="string">"stormwater_polygonalmapfeature.polygon"</span>
+            },
+            <span class="string">"base"</span>: <span class="string">"feature_type"</span>,
+            <span class="string">"utfGrid"</span>: <span class="string">"feature_type, treemap_mapfeature.id AS id"</span>
+        },
+        <span class="string">"basePointModel"</span>: <span class="string">"mapFeature"</span>,
+        <span class="string">"basePolygonModel"</span>: <span class="string">"polygonalMapFeature"</span>,</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-3">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-3">&#182;</a>
+              </div>
+              <p>The tables object gets walked by filtersToTables to build the FROM and JOIN clauses of the SQL string.
+The &quot;depends&quot; property of each item should include any tables used in the &quot;sql&quot; property to JOIN to that table</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        <span class="string">"tables"</span>: {
+            <span class="string">"mapFeature"</span>: {
+                <span class="string">"depends"</span>: [],
+                <span class="string">"sql"</span>: <span class="string">"treemap_mapfeature"</span>
+            },
+            <span class="string">"polygonalMapFeature"</span>: {
+                <span class="string">"depends"</span>: [<span class="string">"mapFeature"</span>],
+                <span class="string">"sql"</span>: <span class="string">"LEFT OUTER JOIN stormwater_polygonalmapfeature ON stormwater_polygonalmapfeature.mapfeature_ptr_id = treemap_mapfeature.id"</span>
+            },
+            <span class="string">"tree"</span>: {
+                <span class="string">"depends"</span>: [<span class="string">"mapFeature"</span>],
+                <span class="string">"sql"</span>: <span class="string">"LEFT OUTER JOIN treemap_tree ON treemap_mapfeature.id = treemap_tree.plot_id"</span>
+            },
+            <span class="string">"species"</span>: {
+                <span class="string">"depends"</span>: [<span class="string">"mapFeature"</span>, <span class="string">"tree"</span>],
+                <span class="string">"sql"</span>: <span class="string">"LEFT OUTER JOIN treemap_species ON treemap_tree.species_id = treemap_species.id"</span>
+            },
+            <span class="string">"mapFeaturePhoto"</span>: {
+                <span class="string">"depends"</span>: [<span class="string">"mapFeature"</span>],
+                <span class="string">"sql"</span>: <span class="string">"LEFT OUTER JOIN treemap_mapfeaturephoto ON treemap_mapfeature.id = treemap_mapfeaturephoto.map_feature_id"</span>
+            },
+            <span class="string">"udf"</span>: {</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-4">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-4">&#182;</a>
+              </div>
+              <p>Despite mapFeature not being referenced in the &quot;sql&quot; property it will
+be used in the filter for udf and so it is required</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>                <span class="string">"depends"</span>: [<span class="string">"mapFeature"</span>],</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-5">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-5">&#182;</a>
+              </div>
+              <p>udf uses a CROSS JOIN, but in filterObjectToWhere a restrictive WHERE clause is added</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>                <span class="string">"sql"</span>: <span class="string">"CROSS JOIN treemap_userdefinedcollectionvalue"</span>
+            }
+        },
+        <span class="string">"where"</span>: {
+            <span class="string">"instance"</span> : <span class="string">"treemap_mapfeature.instance_id = &lt;%= instanceid %&gt;"</span>
+        }
+    },
+    <span class="string">"treeDisplayFilters"</span>: [<span class="string">"EmptyPlot"</span>, <span class="string">"Tree"</span>],
+    <span class="string">"boundaryGrainstoreSql"</span>: <span class="string">"(SELECT the_geom_webmercator FROM treemap_boundary JOIN treemap_instance_boundaries ON treemap_instance_boundaries.boundary_id = treemap_boundary.id WHERE treemap_instance_boundaries.instance_id=&lt;%= instanceid %&gt;) otmfiltersql"</span>,
+    <span class="string">"getBoundarySql"</span> : <span class="string">"SELECT the_geom_webmercator FROM treemap_boundary WHERE id=&lt;%= boundaryId %&gt;"</span>,
+    <span class="string">"customDbFieldNames"</span>: {
+        <span class="string">"geom"</span>: <span class="string">"the_geom_webmercator"</span>
+    },
+    <span class="string">"interactivityForUtfGridRequests"</span>: <span class="string">"id"</span>,
+    <span class="string">"modelMapping"</span>: {
+        <span class="string">"mapFeature"</span>: <span class="string">"treemap_mapfeature"</span>,
+        <span class="string">"polygonalMapFeature"</span>: <span class="string">"stormwater_polygonalmapfeature"</span>,
+        <span class="string">"tree"</span>: <span class="string">"treemap_tree"</span>,
+        <span class="string">"species"</span>: <span class="string">"treemap_species"</span>,
+        <span class="string">"mapFeaturePhoto"</span>: <span class="string">"treemap_mapfeaturephoto"</span>,
+        <span class="string">"udf"</span>: <span class="string">"treemap_userdefinedcollectionvalue"</span>
+    },
+    <span class="string">"udfcTemplates"</span>: {
+        <span class="string">"tree"</span>: <span class="string">"treemap_userdefinedcollectionvalue.field_definition_id=&lt;%= fieldDefId %&gt; AND treemap_userdefinedcollectionvalue.model_id=treemap_tree.id"</span>,
+        <span class="string">"mapFeature"</span>: <span class="string">"treemap_userdefinedcollectionvalue.field_definition_id=&lt;%= fieldDefId %&gt; AND treemap_userdefinedcollectionvalue.model_id=treemap_mapfeature.id"</span>,
+    },
+    <span class="string">"treeMarkerMaxWidth"</span>: <span class="number">20</span>
+};</pre></div></div>
+            
+        </li>
+        
+    </ul>
+  </div>
+</body>
+</html>

--- a/docs/displayFiltersToWhere.html
+++ b/docs/displayFiltersToWhere.html
@@ -24,6 +24,11 @@
               </a>
             
               
+              <a class="source" href="config.html">
+                config.js
+              </a>
+            
+              
               <a class="source" href="displayFiltersToWhere.html">
                 displayFiltersToWhere.js
               </a>
@@ -81,14 +86,34 @@
 <span class="keyword">var</span> _ = require(<span class="string">'underscore'</span>),
     format = require(<span class="string">'util'</span>).format,
     utils = require(<span class="string">'./filterObjectUtils'</span>),
-    config = require(<span class="string">'./config.json'</span>);
+    config = require(<span class="string">'./config'</span>);
 
-module.exports = <span class="keyword">function</span>(displayFilters, models) {
-    <span class="keyword">var</span> featureTypes, inClause;
+module.exports = <span class="keyword">function</span>(displayFilters, restrictFeatureFilters, displayPlotsOnly) {
+    <span class="keyword">var</span> featureTypes, inClause,
+        plotFilters = [<span class="string">'Tree'</span>, <span class="string">'Plot'</span>, <span class="string">'EmptyPlot'</span>],
+        defaultPlotFilter = [<span class="string">'Plot'</span>];
 
-    <span class="keyword">if</span> ( ! _.isArray(models) || models.length === <span class="number">0</span>) {
-        <span class="keyword">throw</span> <span class="keyword">new</span> Error(<span class="string">'The models list must be a non-empty array.'</span>);
-    }</pre></div></div>
+    <span class="keyword">if</span> ( ! _.isBoolean(displayPlotsOnly)) {
+        <span class="keyword">throw</span> <span class="keyword">new</span> Error(<span class="string">'`displayPlotsOnly must be a boolean value.'</span>);
+    }
+
+    <span class="keyword">if</span> (displayPlotsOnly) {
+        <span class="keyword">if</span> (_.isArray(displayFilters) &amp;&amp; displayFilters.length &gt; <span class="number">0</span>) {
+            displayFilters = _.intersection(displayFilters, plotFilters);
+        } <span class="keyword">else</span> {
+            displayFilters = defaultPlotFilter;
+        }
+    }
+
+    <span class="keyword">if</span> (_.isArray(displayFilters)) {
+        displayFilters = _.intersection(
+            displayFilters,
+            _.union(restrictFeatureFilters || [], plotFilters));
+    } <span class="keyword">else</span> {
+        displayFilters = _.union(restrictFeatureFilters || [], defaultPlotFilter);
+    }
+
+    <span class="keyword">if</span> (_.isEmpty(displayFilters)) {</pre></div></div>
             
         </li>
         
@@ -98,51 +123,6 @@ module.exports = <span class="keyword">function</span>(displayFilters, models) {
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-2">&#182;</a>
-              </div>
-              <p>If there are trees referenced in the models list, narrow the display
-filters to only tree display filters.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    <span class="keyword">if</span> (_.contains(models, <span class="string">'tree'</span>)) {
-        <span class="keyword">if</span> (_.isArray(displayFilters) &amp;&amp; displayFilters.length &gt; <span class="number">0</span>) {
-            displayFilters = _.intersection(displayFilters, [<span class="string">'Tree'</span>, <span class="string">'Plot'</span>, <span class="string">'EmptyPlot'</span>]);
-        } <span class="keyword">else</span> {
-            displayFilters = [<span class="string">'Plot'</span>];
-        }
-    }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-3">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-3">&#182;</a>
-              </div>
-              <p>If there are still no display filters (none from query args, and we&#39;re
-not filtering trees), return <code>null</code> to indicate that there is no SQL generated</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    <span class="keyword">if</span> (_.isUndefined(displayFilters) || _.isNull(displayFilters)) {
-        <span class="keyword">return</span> <span class="literal">null</span>;
-    }
-
-    <span class="keyword">if</span> ( ! _.isArray(displayFilters)) {
-        <span class="keyword">throw</span> <span class="keyword">new</span> Error(<span class="string">'The display filter list must be a list to be converted to SQL'</span>);
-    }
-    <span class="keyword">if</span> (_.isEmpty(displayFilters)) {</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-4">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-4">&#182;</a>
               </div>
               <p>With empty display filters, nothing should ever be shown
 &#39;WHERE FALSE&#39; should override any other filters</p>

--- a/docs/filterObjectToWhere.html
+++ b/docs/filterObjectToWhere.html
@@ -24,6 +24,11 @@
               </a>
             
               
+              <a class="source" href="config.html">
+                config.js
+              </a>
+            
+              
               <a class="source" href="displayFiltersToWhere.html">
                 displayFiltersToWhere.js
               </a>
@@ -111,7 +116,7 @@ filter         = predicate
             </div>
             
             <div class="content"><div class='highlight'><pre><span class="keyword">var</span> _ = require(<span class="string">'underscore'</span>),
-    config = require(<span class="string">'./config.json'</span>),
+    config = require(<span class="string">'./config'</span>),
     utils = require(<span class="string">'./filterObjectUtils'</span>),
     format = require(<span class="string">'util'</span>).format;</pre></div></div>
             
@@ -336,6 +341,7 @@ fieldNames, the fieldName is converted to &quot;physicalTableName&quot;.&quot;co
         udfCollectionData = utils.parseUdfCollectionFieldName(fieldName);
         model = udfCollectionData.modelName;
         column = accessHStore(<span class="string">'data'</span>, udfCollectionData.hStoreMember);
+        tableName = config.modelMapping.udf;
     } <span class="keyword">else</span> {
         modelAndColumn = fieldName.split(<span class="string">'.'</span>);
 
@@ -368,8 +374,7 @@ fieldNames, the fieldName is converted to &quot;physicalTableName&quot;.&quot;co
 
             column = customColumnName || column;
             column = <span class="string">'"'</span> + column + <span class="string">'"'</span>;
-        }
-    }</pre></div></div>
+        }</pre></div></div>
             
         </li>
         
@@ -385,11 +390,13 @@ physical table name.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>    <span class="keyword">if</span> (!config.modelMapping[model]) {
-        <span class="keyword">throw</span> <span class="keyword">new</span> Error(<span class="string">'The model name must be one of the following: '</span> +
-                        Object.keys(config.modelMapping).join(<span class="string">', '</span>) + <span class="string">'. Not '</span> + model);
+            <div class="content"><div class='highlight'><pre>        <span class="keyword">if</span> (!config.modelMapping[model]) {
+            <span class="keyword">throw</span> <span class="keyword">new</span> Error(<span class="string">'The model name must be one of the following: '</span> +
+                            Object.keys(config.modelMapping).join(<span class="string">', '</span>) + <span class="string">'. Not '</span> + model);
+        }
+
+        tableName = config.modelMapping[model]; <span class="comment">// model is not sanitized because there is a whitelist</span>
     }
-    tableName = config.modelMapping[model]; <span class="comment">// model is not sanitized because there is a whitelist</span>
 
     <span class="keyword">return</span> <span class="string">'"'</span> + tableName + <span class="string">'".'</span> + column;
 }</pre></div></div>
@@ -659,13 +666,7 @@ WHERE clause to act as a join criteria, since the table is CROSS JOINed</p>
             
             <div class="content"><div class='highlight'><pre>    <span class="keyword">if</span> (fieldName.indexOf(<span class="string">'udf:'</span>) === <span class="number">0</span>) {
         <span class="keyword">var</span> udfCollectionData = utils.parseUdfCollectionFieldName(fieldName);
-        <span class="keyword">var</span> model = udfCollectionData.modelName;
-        <span class="keyword">var</span> udfcTemplate = _.template(config.udfcTemplates[model]);
-
-        filterStatements.push(udfcTemplate({fieldDefId: udfCollectionData.fieldDefId}));
-    }
-    <span class="keyword">return</span> <span class="string">'('</span> + filterStatements.join(<span class="string">' AND '</span>) + <span class="string">')'</span> ;
-}</pre></div></div>
+        <span class="keyword">var</span> model = udfCollectionData.modelName;</pre></div></div>
             
         </li>
         
@@ -675,6 +676,26 @@ WHERE clause to act as a join criteria, since the table is CROSS JOINed</p>
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-27">&#182;</a>
+              </div>
+              <p>Most collection UDFs relate to MapFeatures.  The odd duck is Tree Collection UDFs</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        <span class="keyword">var</span> udfcTemplate = _.template(model === <span class="string">"tree"</span> ? config.udfcTemplates.tree : config.udfcTemplates.mapFeature);
+
+        filterStatements.push(udfcTemplate({fieldDefId: udfCollectionData.fieldDefId}));
+    }
+    <span class="keyword">return</span> <span class="string">'('</span> + filterStatements.join(<span class="string">' AND '</span>) + <span class="string">')'</span> ;
+}</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-28">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-28">&#182;</a>
               </div>
               <p><code>objectToSql</code> converts a filter object to a valid SQL WHERE clause.</p>
 
@@ -700,11 +721,11 @@ WHERE clause to act as a join criteria, since the table is CROSS JOINed</p>
         </li>
         
         
-        <li id="section-28">
+        <li id="section-29">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-28">&#182;</a>
+                <a class="pilcrow" href="#section-29">&#182;</a>
               </div>
               <p><code>arrayToSql</code> converts a combinator array into a valid SQL WHERE clause.</p>
 
@@ -721,11 +742,11 @@ WHERE clause to act as a join criteria, since the table is CROSS JOINed</p>
         </li>
         
         
-        <li id="section-29">
+        <li id="section-30">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-29">&#182;</a>
+                <a class="pilcrow" href="#section-30">&#182;</a>
               </div>
               <p><code>filterToSql</code> converts any filter object or combinator array into a valid SQL WHERE clause.</p>
 

--- a/docs/filterObjectUtils.html
+++ b/docs/filterObjectUtils.html
@@ -24,6 +24,11 @@
               </a>
             
               
+              <a class="source" href="config.html">
+                config.js
+              </a>
+            
+              
               <a class="source" href="displayFiltersToWhere.html">
                 displayFiltersToWhere.js
               </a>
@@ -80,7 +85,7 @@
 
 <span class="keyword">var</span> _ = require(<span class="string">'underscore'</span>);
 <span class="keyword">var</span> moment = require(<span class="string">'moment'</span>);
-<span class="keyword">var</span> config = require(<span class="string">'./config.json'</span>);</pre></div></div>
+<span class="keyword">var</span> config = require(<span class="string">'./config'</span>);</pre></div></div>
             
         </li>
         
@@ -264,14 +269,28 @@ syntax into an object of the relevant components.</p>
     fieldDefIdAndHStoreMember = tokens[<span class="number">2</span>].split(<span class="string">'.'</span>);
 
     <span class="keyword">return</span> {
-        modelName: <span class="string">'udf:'</span> + tokens[<span class="number">1</span>],
+        modelName: tokens[<span class="number">1</span>],
         fieldDefId: fieldDefIdAndHStoreMember[<span class="number">0</span>],
         hStoreMember: fieldDefIdAndHStoreMember[<span class="number">1</span>]
     };
 }
 
+<span class="function"><span class="keyword">function</span> <span class="title">filterObjectKeys</span><span class="params">(fObj)</span> {</span>
+    <span class="keyword">var</span> keys = [];
+    <span class="keyword">if</span> (_.isArray(fObj)) {
+        traverseCombinator(fObj, <span class="function"><span class="keyword">function</span> <span class="params">(nestedfObj)</span> {</span>
+            keys = keys.concat(filterObjectKeys(nestedfObj));
+        });
+    } <span class="keyword">else</span> {
+        _.each(fObj, <span class="keyword">function</span>(__, key) { keys.push(key); });
+    }
+    <span class="keyword">return</span> keys;
+}
+
 module.exports = {
     traverseCombinator: traverseCombinator,
+
+    filterObjectKeys: filterObjectKeys,
 
     isTreeInDisplayFilters: isTreeInDisplayFilters,
 

--- a/docs/filtersToTables.html
+++ b/docs/filtersToTables.html
@@ -24,6 +24,11 @@
               </a>
             
               
+              <a class="source" href="config.html">
+                config.js
+              </a>
+            
+              
               <a class="source" href="displayFiltersToWhere.html">
                 displayFiltersToWhere.js
               </a>
@@ -79,7 +84,7 @@
             <div class="content"><div class='highlight'><pre><span class="string">"use strict"</span>;
 
 <span class="keyword">var</span> _ = require(<span class="string">'underscore'</span>);
-<span class="keyword">var</span> config = require(<span class="string">'./config.json'</span>);
+<span class="keyword">var</span> config = require(<span class="string">'./config'</span>);
 <span class="keyword">var</span> utils = require(<span class="string">"./filterObjectUtils"</span>);
 
 exports = module.exports = <span class="function"><span class="keyword">function</span> <span class="params">(filterObject, displayFilters, isPolygonRequest)</span> {</span>
@@ -144,28 +149,25 @@ clauses.</p>
             </div>
             
             <div class="content"><div class='highlight'><pre><span class="function"><span class="keyword">function</span> <span class="title">getModelsForFilterObject</span><span class="params">(object)</span> {</span>
-    <span class="keyword">var</span> models = [];
-    <span class="keyword">if</span> (_.isArray(object)) {
-        utils.traverseCombinator(object, <span class="keyword">function</span>(filter) {
-            models = models.concat(getModelsForFilterObject(filter));
-        });
-    } <span class="keyword">else</span> <span class="keyword">if</span> (_.isObject(object) &amp;&amp; _.size(object) &gt; <span class="number">0</span>) {
-        _.each(object, <span class="keyword">function</span>(predicate, fieldName) {
-            <span class="keyword">var</span> model;
-            <span class="keyword">if</span> (fieldName.indexOf(<span class="string">'udf:'</span>) === <span class="number">0</span>) {
-                model = utils.parseUdfCollectionFieldName(fieldName).modelName;
-            } <span class="keyword">else</span> {
-                model = fieldName.split(<span class="string">'.'</span>)[<span class="number">0</span>];
+    <span class="function"><span class="keyword">function</span> <span class="title">fieldNameToModel</span><span class="params">(fieldName)</span> {</span>
+        <span class="keyword">var</span> model;
+        <span class="keyword">if</span> (fieldName.indexOf(<span class="string">'udf:'</span>) === <span class="number">0</span>) {
+            model = utils.parseUdfCollectionFieldName(fieldName).modelName;
+            <span class="keyword">if</span> (model === <span class="string">"tree"</span>) {
+                <span class="keyword">return</span> [<span class="string">"tree"</span>, <span class="string">"udf"</span>];
             }
-            <span class="keyword">if</span> (!config.modelMapping[model]) {
-                <span class="keyword">throw</span> <span class="keyword">new</span> Error(<span class="string">'The model name must be one of the following: '</span> +
-                        Object.keys(config.modelMapping).join(<span class="string">', '</span>) + <span class="string">'. Not '</span> + model);
-            }
-            models.push(model);
-        });
-    }
+            <span class="keyword">return</span> [<span class="string">"udf"</span>];
+        }
 
-    <span class="keyword">return</span> _.uniq(models);
+        model = fieldName.split(<span class="string">'.'</span>)[<span class="number">0</span>];
+
+        <span class="keyword">if</span> (!config.modelMapping[model]) {
+            <span class="keyword">throw</span> <span class="keyword">new</span> Error(<span class="string">'The model name must be one of the following: '</span> +
+                            Object.keys(config.modelMapping).join(<span class="string">', '</span>) + <span class="string">'. Not '</span> + model);
+        }
+        <span class="keyword">return</span> [model];
+    }
+    <span class="keyword">return</span> _.uniq(_.flatten(_.map(utils.filterObjectKeys(object), fieldNameToModel)));
 }</pre></div></div>
             
         </li>

--- a/docs/makeSql.html
+++ b/docs/makeSql.html
@@ -24,6 +24,11 @@
               </a>
             
               
+              <a class="source" href="config.html">
+                config.js
+              </a>
+            
+              
               <a class="source" href="displayFiltersToWhere.html">
                 displayFiltersToWhere.js
               </a>
@@ -116,7 +121,8 @@ That particularly hurts in production where we have just one DB server and four 
 <span class="keyword">var</span> displayFiltersToWhere = require(<span class="string">'./displayFiltersToWhere'</span>);
 <span class="keyword">var</span> filtersToTables = require(<span class="string">'./filtersToTables'</span>);
 <span class="keyword">var</span> addDefaultsToFilter = require(<span class="string">'./addDefaultsToFilter'</span>);
-<span class="keyword">var</span> config = require(<span class="string">'./config.json'</span>);</pre></div></div>
+<span class="keyword">var</span> config = require(<span class="string">'./config'</span>);
+<span class="keyword">var</span> utils = require(<span class="string">'./filterObjectUtils'</span>);</pre></div></div>
             
         </li>
         
@@ -133,19 +139,21 @@ directly into SQL</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre><span class="function"><span class="keyword">function</span> <span class="title">makeSqlForMapFeatures</span><span class="params">(filterString, displayString, instanceid, zoom, isUtfGridRequest, isPolygonRequest)</span> {</span>
+            <div class="content"><div class='highlight'><pre><span class="function"><span class="keyword">function</span> <span class="title">makeSqlForMapFeatures</span><span class="params">(filterString, displayString, restrictFeatureString, instanceid,
+                               zoom, isUtfGridRequest, isPolygonRequest)</span> {</span>
     <span class="keyword">var</span> geom_spec = config.sqlForMapFeatures.fields.geom,
         geom_field = isPolygonRequest ? geom_spec.polygon : geom_spec.point,
         otherFields = (isUtfGridRequest ? config.sqlForMapFeatures.fields.utfGrid : config.sqlForMapFeatures.fields.base),
         parsedFilterObject = filterString ? JSON.parse(filterString) : {},
         displayFilters = displayString ? JSON.parse(displayString) : <span class="literal">undefined</span>,
+        restrictFeatureFilters = restrictFeatureString ? JSON.parse(restrictFeatureString) : <span class="literal">undefined</span>,
 
         filterObject = addDefaultsToFilter(parsedFilterObject, zoom, isPolygonRequest),
 
         tables = filtersToTables(filterObject, displayFilters, isPolygonRequest),
 
         where = <span class="string">''</span>,
-        displayClause = displayFiltersToWhere(displayFilters, tables.models),
+        displayClause = displayFiltersToWhere(displayFilters, restrictFeatureFilters, displayPlotsOnly(filterObject)),
         filterClause = filterObjectToWhere(filterObject),
         instanceClause = (instanceid ? _.template(config.sqlForMapFeatures.where.instance)({instanceid: instanceid}) : <span class="literal">null</span>);
 
@@ -198,6 +206,26 @@ add DISTINCT so we only get one row.</p>
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-5">&#182;</a>
+              </div>
+              <p>If there are trees referenced in the filter object, narrow the
+display filters to only tree display filters.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="function"><span class="keyword">function</span> <span class="title">displayPlotsOnly</span><span class="params">(filterObject)</span> {</span>
+    <span class="keyword">var</span> isTreeFilterObject = <span class="keyword">function</span>(s) {<span class="keyword">return</span> s.substring(<span class="number">0</span>, <span class="number">4</span>) === <span class="string">'tree'</span>; };
+    <span class="keyword">var</span> treeKeys = _.filter(utils.filterObjectKeys(filterObject), isTreeFilterObject);
+    <span class="keyword">return</span> treeKeys.length &gt; <span class="number">0</span>;
+}</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-6">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-6">&#182;</a>
               </div>
               <p>Create a SQL query to return info about boundaries.
 Assumes that instanceid is an integer, ready to be plugged

--- a/docs/server.html
+++ b/docs/server.html
@@ -24,6 +24,11 @@
               </a>
             
               
+              <a class="source" href="config.html">
+                config.js
+              </a>
+            
+              
               <a class="source" href="displayFiltersToWhere.html">
                 displayFiltersToWhere.js
               </a>
@@ -83,7 +88,7 @@
 <span class="keyword">var</span> cluster = require(<span class="string">'cluster'</span>);
 <span class="keyword">var</span> fs = require(<span class="string">'fs'</span>);
 <span class="keyword">var</span> makeSql = require(<span class="string">'./makeSql.js'</span>);
-<span class="keyword">var</span> config = require(<span class="string">'./config.json'</span>);
+<span class="keyword">var</span> config = require(<span class="string">'./config'</span>);
 <span class="keyword">var</span> settings = require(<span class="string">'./settings.json'</span>);
 
 <span class="keyword">var</span> workerCount = process.env.WORKERS || require(<span class="string">'os'</span>).cpus().length;
@@ -213,7 +218,8 @@ each metatile multiple times, making things slower rather than faster.</p>
             </div>
             
             <div class="content"><div class='highlight'><pre>    req2params: <span class="keyword">function</span>(req, callback) {
-        <span class="keyword">var</span> instanceid, isUtfGridRequest, isPolygonRequest, table, zoom, filterString, displayString;</pre></div></div>
+        <span class="keyword">var</span> instanceid, isUtfGridRequest, isPolygonRequest, table,
+            zoom, filterString, displayString, restrictFeatureString;</pre></div></div>
             
         </li>
         
@@ -238,9 +244,11 @@ using the magic column name &quot;the_geom_webmercator&quot;.)</p>
             <span class="keyword">if</span> (table === <span class="string">'treemap_mapfeature'</span> || isPolygonRequest) {
                 filterString = req.query[config.filterQueryArgumentName];
                 displayString = req.query[config.displayQueryArgumentName];
+                restrictFeatureString = req.query[config.restrictFeatureQueryArgumentName];
                 isUtfGridRequest = (req.params.format === <span class="string">'grid.json'</span>);
                 req.query.sql = makeSql.makeSqlForMapFeatures(filterString,
                                                               displayString,
+                                                              restrictFeatureString,
                                                               instanceid,
                                                               zoom,
                                                               isUtfGridRequest,

--- a/makeSql.js
+++ b/makeSql.js
@@ -36,19 +36,21 @@ var utils = require('./filterObjectUtils');
 // Create a SQL query to return info about map features.
 // Assumes that instanceid is an integer, ready to be plugged
 // directly into SQL
-function makeSqlForMapFeatures(filterString, displayString, instanceid, zoom, isUtfGridRequest, isPolygonRequest) {
+function makeSqlForMapFeatures(filterString, displayString, restrictFeatureString, instanceid,
+                               zoom, isUtfGridRequest, isPolygonRequest) {
     var geom_spec = config.sqlForMapFeatures.fields.geom,
         geom_field = isPolygonRequest ? geom_spec.polygon : geom_spec.point,
         otherFields = (isUtfGridRequest ? config.sqlForMapFeatures.fields.utfGrid : config.sqlForMapFeatures.fields.base),
         parsedFilterObject = filterString ? JSON.parse(filterString) : {},
         displayFilters = displayString ? JSON.parse(displayString) : undefined,
+        restrictFeatureFilters = restrictFeatureString ? JSON.parse(restrictFeatureString) : undefined,
 
         filterObject = addDefaultsToFilter(parsedFilterObject, zoom, isPolygonRequest),
 
         tables = filtersToTables(filterObject, displayFilters, isPolygonRequest),
 
         where = '',
-        displayClause = displayFiltersToWhere(displayFilters, displayPlotsOnly(filterObject)),
+        displayClause = displayFiltersToWhere(displayFilters, restrictFeatureFilters, displayPlotsOnly(filterObject)),
         filterClause = filterObjectToWhere(filterObject),
         instanceClause = (instanceid ? _.template(config.sqlForMapFeatures.where.instance)({instanceid: instanceid}) : null);
 

--- a/server.js
+++ b/server.js
@@ -62,7 +62,8 @@ var windshaftConfig = {
 
     // Tell server how to handle HTTP request 'req' (by specifying properties in req.params).
     req2params: function(req, callback) {
-        var instanceid, isUtfGridRequest, isPolygonRequest, table, zoom, filterString, displayString;
+        var instanceid, isUtfGridRequest, isPolygonRequest, table,
+            zoom, filterString, displayString, restrictFeatureString;
         // Specify SQL subquery to extract desired features from desired DB layer.
         // (This will be wrapped in an outer query, in many cases extracting geometry
         // using the magic column name "the_geom_webmercator".)
@@ -74,9 +75,11 @@ var windshaftConfig = {
             if (table === 'treemap_mapfeature' || isPolygonRequest) {
                 filterString = req.query[config.filterQueryArgumentName];
                 displayString = req.query[config.displayQueryArgumentName];
+                restrictFeatureString = req.query[config.restrictFeatureQueryArgumentName];
                 isUtfGridRequest = (req.params.format === 'grid.json');
                 req.query.sql = makeSql.makeSqlForMapFeatures(filterString,
                                                               displayString,
+                                                              restrictFeatureString,
                                                               instanceid,
                                                               zoom,
                                                               isUtfGridRequest,

--- a/test/testDisplayFiltersToWhere.js
+++ b/test/testDisplayFiltersToWhere.js
@@ -3,13 +3,15 @@
 var assert = require("assert");
 var displayFiltersToWhere = require("../displayFiltersToWhere");
 
-var assertSqlForModels = function(list, displayPlotsOnly, expectedSql) {
-    var result = displayFiltersToWhere(list, displayPlotsOnly);
+var assertSqlForModels = function(displayFilter, restrictFeatureFilter,
+                                  displayPlotsOnly, expectedSql) {
+    var result = displayFiltersToWhere(displayFilter, restrictFeatureFilter,
+                                       displayPlotsOnly);
     assert.equal(result, expectedSql);
 };
 
-var assertSql = function(list, expectedSql) {
-    assertSqlForModels(list, false, expectedSql);
+var assertSql = function(displayFilter, restrictFeatureFilter, expectedSql) {
+    assertSqlForModels(displayFilter, restrictFeatureFilter, false, expectedSql);
 };
 
 describe('displayFiltersToWhere', function() {
@@ -17,62 +19,110 @@ describe('displayFiltersToWhere', function() {
     // NULL AND EMPTY HANDLING
     it('raises an error when passed a non-boolean for displayPlotsOnly', function() {
         assert.throws(function() {
-            displayFiltersToWhere(null, null);
+            displayFiltersToWhere(null, null, null);
         }, Error);
 
         assert.throws(function() {
-            displayFiltersToWhere(['Tree'], undefined);
+            displayFiltersToWhere(null, undefined, null);
         }, Error);
 
         assert.throws(function() {
-            displayFiltersToWhere(['Tree'], 2);
+            displayFiltersToWhere(['Tree'], undefined, undefined);
         }, Error);
 
         assert.throws(function() {
-            displayFiltersToWhere(['Tree'], []);
+            displayFiltersToWhere(['Tree'], null, undefined);
+        }, Error);
+
+        assert.throws(function() {
+            displayFiltersToWhere(['Tree'], undefined, 2);
+        }, Error);
+
+        assert.throws(function() {
+            displayFiltersToWhere(['Tree'], null, 2);
+        }, Error);
+
+        assert.throws(function() {
+            displayFiltersToWhere(['Tree'], undefined, []);
         }, Error);
     });
 
-    it('returns null when passed null and not instructed to show only plots', function() {
-        assertSqlForModels(null, false, null);
+    it('defaults to plot restriction when passed null/null and not instructed to show only plots', function() {
+        assertSqlForModels(null, null, false,
+                           "\"treemap_mapfeature\".\"feature_type\" IN ( 'Plot' )");
     });
 
-    it('returns null when passed undefined and not instructed to show only plots', function() {
-        assertSqlForModels(undefined, false, null);
+    it('defaults to plot restriction when passed null/undefined and not instructed to show only plots', function() {
+        assertSqlForModels(null, undefined, false,
+                           "\"treemap_mapfeature\".\"feature_type\" IN ( 'Plot' )");
+    });
+
+    it('defaults to plot restriction when passed undefined/undefined and not instructed to show only plots', function() {
+        assertSqlForModels(undefined, undefined, false,
+                          "\"treemap_mapfeature\".\"feature_type\" IN ( 'Plot' )");
     });
 
     // MODEL LIST HANDLING
     it('returns an IN clause for only Plots when instructed to show only plots', function() {
-        assertSqlForModels(null, true, '"treemap_mapfeature"."feature_type" IN ( \'Plot\' )');
+        assertSqlForModels(null, undefined,
+                           true, '"treemap_mapfeature"."feature_type" IN ( \'Plot\' )');
     });
 
     // EMPTY LIST HANDLING
     it('returns a FALSE where clause for an empty list', function() {
-        assertSql([], 'FALSE');
+        assertSql([], undefined, 'FALSE');
     });
+
+    it('returns a FALSE where clause for an empty list with full restrict filters', function() {
+        assertSql([], [], 'FALSE');
+    });
+
+    it('returns a FALSE where clause for an empty list with some filters', function() {
+        assertSql([], ['Plot'], 'FALSE');
+    });
+
+    // ABITRARY INTERSECT HANDLING
+    it('returns unrestricted output when restriction equals display filter', function() {
+        assertSql(['Tree'], ['Tree'],
+                  '(("treemap_tree"."id" IS NOT NULL) AND ("treemap_mapfeature"."feature_type" = \'Plot\'))');
+    });
+
+    it('returns unrestricted output when restriction is superset of display filter', function() {
+        assertSql(['Tree'], ['Tree', 'Plot'],
+                  '(("treemap_tree"."id" IS NOT NULL) AND ("treemap_mapfeature"."feature_type" = \'Plot\'))');
+    });
+
+
+    it('returns fully restricted output when restriction has no intersect with display filter', function() {
+        assertSql(['BikeRack'], ['FireHydrant'], 'FALSE');
+    });
+
 
     // TREE MODEL HANDLING
     it('returns two clauses ANDed together w/ is NOT NULL for ["Tree"]', function() {
-        assertSql(['Tree'], '(("treemap_tree"."id" IS NOT NULL) AND ("treemap_mapfeature"."feature_type" = \'Plot\'))');
+        assertSql(['Tree'], undefined,
+                  '(("treemap_tree"."id" IS NOT NULL) AND ("treemap_mapfeature"."feature_type" = \'Plot\'))');
     });
 
     it('returns two clauses ANDed together w/ IS NULL for ["EmptyPlot"]', function() {
-        assertSql(['EmptyPlot'], '(("treemap_tree"."id" IS NULL) AND ("treemap_mapfeature"."feature_type" = \'Plot\'))');
+        assertSql(['EmptyPlot'], undefined,
+                  '(("treemap_tree"."id" IS NULL) AND ("treemap_mapfeature"."feature_type" = \'Plot\'))');
     });
 
     it('returns two ANDed clauses ORed w/ third clause for ["Tree", "FireHydrant"]', function() {
-        assertSql(['Tree', 'FireHydrant'],
-            '(("treemap_tree"."id" IS NOT NULL) AND ("treemap_mapfeature"."feature_type" = \'Plot\'))' +
-                ' OR ("treemap_mapfeature"."feature_type" = \'FireHydrant\')');
+        assertSql(['Tree', 'FireHydrant'], ['FireHydrant'],
+                  '(("treemap_tree"."id" IS NOT NULL) AND ("treemap_mapfeature"."feature_type" = \'Plot\'))' +
+                  ' OR ("treemap_mapfeature"."feature_type" = \'FireHydrant\')');
     });
 
     it('returns IN clause for all non-plot models', function() {
-        assertSql(['FireHydrant'],
+        assertSql(['FireHydrant'], ['FireHydrant'],
                   '"treemap_mapfeature"."feature_type" IN ( \'FireHydrant\' )');
     });
 
     // MapFeature HANDLING
     it('returns IN clause for all non-tree models', function() {
-        assertSql(['FireHydrant', 'Plot'], '"treemap_mapfeature"."feature_type" IN ( \'FireHydrant\', \'Plot\' )');
+        assertSql(['FireHydrant', 'Plot'], ['FireHydrant'],
+                  '"treemap_mapfeature"."feature_type" IN ( \'FireHydrant\', \'Plot\' )');
     });
 });

--- a/test/testMakeSql.js
+++ b/test/testMakeSql.js
@@ -25,6 +25,7 @@ describe('makeSql', function() {
             sql = makeSql.makeSqlForMapFeatures(
                 options.filter,
                 options.displayFilter,
+                options.restrictFeatureFilter,
                 options.instanceId,
                 zoom,
                 options.isUtfGridRequest,
@@ -78,8 +79,8 @@ describe('makeSql', function() {
 
     // WHERE
 
-    it('has no WHERE clause for plain request', function() {
-        assertSqlLacks({
+    it('has WHERE clause for plain request', function() {
+        assertSqlContains({
             expected: 'WHERE'
         });
     });
@@ -105,8 +106,8 @@ describe('makeSql', function() {
         });
     });
 
-    it('lacks WHERE clause when no display filter passed', function() {
-        assertSqlLacks({
+    it('contains WHERE clause even when no display filter passed', function() {
+        assertSqlContains({
             expected: ' WHERE '
         });
     });
@@ -131,6 +132,7 @@ describe('makeSql', function() {
         assertSqlEqual({
             isPolygonRequest: true,
             displayFilter: '["Tree", "FireHydrant"]',
+            restrictFeatureFilter: undefined,
             filter: '{"tree.diameter":{"MIN":1,"MAX":100}}',
             expected: '( SELECT DISTINCT(stormwater_polygonalmapfeature.polygon) AS the_geom_webmercator, ' +
                 'feature_type FROM treemap_mapfeature LEFT OUTER JOIN treemap_tree ON ' +


### PR DESCRIPTION
This has a lot of overlap but is provided out of band with
displayFilters because it is meant to be configured at a separate level.

displayFilters are dynamically changed per request by the end-user based
on a search filter, restrict filters are baked into the tiler URL for an
instance based on the eligible MapFeature subclasses for that instance.