### PR TITLE
Add rollbar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ OTM_DB_PORT = 5432
 
 OTM_CACHE_HOST = '127.0.0.1',
 OTM_CACHE_PORT = 6379
+
+OTM_STACK_TYPE = 'development'
+```
+
+There is also an optional environment variable for reporting errors to [Rollbar](rollbar.com).
+```
+ROLLBAR_SERVER_SIDE_ACCESS_TOKEN=....
 ```
 
 Please view the [javascript documentation](http://opentreemap.github.io/otm-tiler/server.html).

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7,6 +7,33 @@
       "from": "moment@~2.1.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.1.0.tgz"
     },
+    "rollbar": {
+      "version": "0.5.9",
+      "from": "rollbar@",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-0.5.9.tgz",
+      "dependencies": {
+        "node-uuid": {
+          "version": "1.4.3",
+          "from": "node-uuid@1.4.x",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+        },
+        "lru-cache": {
+          "version": "2.2.4",
+          "from": "lru-cache@~2.2.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@~5.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+        },
+        "async": {
+          "version": "1.2.1",
+          "from": "async@~1.2.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
+        }
+      }
+    },
     "semver": {
       "version": "1.1.4",
       "from": "semver@~1.1.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "moment": "~2.1.0",
+    "rollbar": "^0.5.9",
     "semver": "~1.1.0",
     "underscore": "~1.3",
     "windshaft": "0.19.4"


### PR DESCRIPTION
Builds on top of https://github.com/OpenTreeMap/otm-tiler/pull/84, only the last commit is new.

To test I used a filter string with a known bad format, e.g. `http://33.33.34.35/tile/c4ca4238a0b923820dcc509a6f75849b/table/treemap_mapfeature/15/8638/11870.png?instance_id=2&q=%22not_a_model_name%22` and verified that I saw the exception produced on the rollbar console.