### PR TITLE
Add support for StatsD

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,6 +26,10 @@ var styles = {
 
 var windshaftConfig = {
     useProfiler: false,  // if true, returns X-Tiler-Profiler header with rendering times
+    statsd: {
+        host: process.env.OTM_STATSD_HOST || '127.0.0.1',
+        port: process.env.OTM_STATSD_PORT || 8125
+    },
     enable_cors: true,
     mapnik: {
         // When looking for objects to render on a tile, mapnik by default adds 64 pixels


### PR DESCRIPTION
If the `useProfiler` configuration setting is enabled, Windshaft will send internal metrics to the configured StatsD endpoint.

Depends on https://github.com/OpenTreeMap/otm-cloud/pull/93.

---

**Testing**

Ensure that the `useProfiler` setting is enabled in Windshaft's configuration. Then, restart the `otm-tiler` service and check the Librato UI (metrics flush every 60 seconds) to see if metrics are being populated.