### PR TITLE
Restore database URL parameter to support legacy tile clients

### DIFF
--- a/server.js
+++ b/server.js
@@ -67,8 +67,11 @@ var windshaftConfig = {
     }, // See grainstore npm for other options
 
     // Parse params from the request URL
-    base_url: '/:cache_buster/table/:table',
-    base_url_notable: '/:cache_buster/table',
+    // The parameter after database is unused, but left in for legacy reasons
+    // so that older versions of the mobile apps will be able to continue to
+    // make tile requests
+    base_url: '/:cache_buster/database/:unused/table/:table',
+    base_url_notable: '/:cache_buster/database/:unused/table',
 
     // Tell server how to handle HTTP request 'req' (by specifying properties in req.params).
     req2params: function(req, callback) {


### PR DESCRIPTION
Older versions of the mobile apps still use tile URLs that contain
the database URL parameter, which is no longer used.

By restoring that URL paramter we restore support for those legacy clients

We however will continue to pull the database name from environment
settings, not from the URL parameter, which is now present but unused.

Connects to #96