### PR TITLE
Fix SQL for custom field queries

### DIFF
--- a/addDefaultsToFilter.js
+++ b/addDefaultsToFilter.js
@@ -6,6 +6,7 @@ module.exports = function(filterObject, zoom, isPolygonRequest) {
     // The client starts requesting the polygon layer at zoom level 15 and
     // greater.  For tiles at that zoom and greater, we should exclude polygon
     // points, since we will be showing the polygon itself instead.
+
     if (zoom >= 15 && !isPolygonRequest) {
         var defaults = {'polygonalMapFeature.polygon': {'ISNULL': true}};
         return _.extend({}, defaults, filterObject);

--- a/config.js
+++ b/config.js
@@ -38,11 +38,11 @@ module.exports = {
             },
             "rainGarden": {
                 "depends": ["mapFeature"],
-                "sql": "JOIN stormwater_raingarden ON treemap_mapfeature.id = stormwater_raingarden.mapfeature_ptr_id"
+                "sql": "JOIN stormwater_raingarden ON treemap_mapfeature.id = stormwater_raingarden.polygonalmapfeature_ptr_id"
             },
             "bioswale": {
                 "depends": ["mapFeature"],
-                "sql": "JOIN stormwater_bioswale ON treemap_mapfeature.id = stormwater_bioswale.mapfeature_ptr_id"
+                "sql": "JOIN stormwater_bioswale ON treemap_mapfeature.id = stormwater_bioswale.polygonalmapfeature_ptr_id"
             },
             "tree": {
                 "depends": ["mapFeature"],

--- a/filterObjectToWhere.js
+++ b/filterObjectToWhere.js
@@ -117,7 +117,7 @@ function transformWithinRadiusPredicate(predicateValue) {
 // accessHStore('grab_bag', 'is_valid') -> "grab_bag"->'is_valid'
 function accessHStore(hStoreColumn, accessor) {
     // TODO: sql injection? why don't we call sanitize?
-    var t = _.template('"<%= hStoreColumn %>"->\'<%= accessor %>\'');
+    var t = _.template('"<%= hStoreColumn %>"::hstore->\'<%= accessor %>\'');
     return t({hStoreColumn: hStoreColumn,
               accessor: accessor.replace("'","''")});
 }
@@ -291,6 +291,8 @@ function fieldNameAndPredicateToSql(fieldName, predicate) {
                                         columnName, utils.DATETIME_FORMATS.date);
                 } else if (_.isNumber(f.value)) {
                     columnName = format("( %s )::float ", columnName);
+                } else {
+                    columnName = format("(%s)", columnName);
                 }
             }
             return columnName + ' ' + f.matcher + ' ' + f.value;

--- a/test/testFilterObjectToWhere.js
+++ b/test/testFilterObjectToWhere.js
@@ -92,16 +92,16 @@ describe('filterObjectToWhere', function() {
     // UDF MATCHES
     it('processes udf values', function() {
         assertSql({"mapFeature.udf:Clever Name": {"LIKE": "Market St"}},
-                  "(\"treemap_mapfeature\".\"udfs\"->'Clever Name' " +
+                  "((\"treemap_mapfeature\".\"udfs\"::hstore->'Clever Name') " +
                   "ILIKE '%Market St%')");
     });
 
     it('converts mf subclasses to mapfeature for scalar udf searches', function() {
         assertSql({"plot.udf:Clever Name": {"LIKE": "Market St"}},
-                  "(\"treemap_mapfeature\".\"udfs\"->'Clever Name' " +
+                  "((\"treemap_mapfeature\".\"udfs\"::hstore->'Clever Name') " +
                   "ILIKE '%Market St%')");
         assertSql({"bioswale.udf:Clever Name": {"LIKE": "Market St"}},
-                  "(\"treemap_mapfeature\".\"udfs\"->'Clever Name' " +
+                  "((\"treemap_mapfeature\".\"udfs\"::hstore->'Clever Name') " +
                   "ILIKE '%Market St%')");
         assert.throws(function () {
             filterObjectToWhere({"fool.udf:Clever Name": {"LIKE": "Market St"}});
@@ -111,17 +111,17 @@ describe('filterObjectToWhere', function() {
     // UDF COLLECTION MATCHES
     it('processes udf values, includes JOIN criteria in WHERE clause', function() {
         assertSql({"udf:tree:18.Action": {"LIKE": "Watering"}},
-                  "(\"treemap_userdefinedcollectionvalue\".\"data\"->'Action' ILIKE '%Watering%'" +
+                  "((\"treemap_userdefinedcollectionvalue\".\"data\"::hstore->'Action') ILIKE '%Watering%'" +
                   " AND treemap_userdefinedcollectionvalue.field_definition_id=18" +
                   " AND treemap_userdefinedcollectionvalue.model_id=treemap_tree.id)");
     });
 
     it('processes allows multiple UDF collections to be searched', function() {
         assertSql({"udf:tree:18.Action": {"LIKE": "Watering"}, "udf:plot:17.Action": {"LIKE": "Destroying"}},
-                  "(\"treemap_userdefinedcollectionvalue\".\"data\"->'Action' ILIKE '%Watering%'" +
+                  "((\"treemap_userdefinedcollectionvalue\".\"data\"::hstore->'Action') ILIKE '%Watering%'" +
                   " AND treemap_userdefinedcollectionvalue.field_definition_id=18" +
                   " AND treemap_userdefinedcollectionvalue.model_id=treemap_tree.id)" +
-                  " AND (\"treemap_userdefinedcollectionvalue\".\"data\"->'Action' ILIKE '%Destroying%'" +
+                  " AND ((\"treemap_userdefinedcollectionvalue\".\"data\"::hstore->'Action') ILIKE '%Destroying%'" +
                   " AND treemap_userdefinedcollectionvalue.field_definition_id=17" +
                   " AND treemap_userdefinedcollectionvalue.model_id=treemap_mapfeature.id)");
     });
@@ -325,15 +325,15 @@ describe('filterObjectToWhere', function() {
 
     it('converts hstore date fields from string to postgres date without timezone', function () {
         assertSql({"tree.udf:Date": {"MIN": "2014-03-02 00:00:00"}},
-                  "(to_date(\"treemap_tree\".\"udfs\"->'Date'::text, 'YYYY-MM-DD') " +
+                  "(to_date(\"treemap_tree\".\"udfs\"::hstore->'Date'::text, 'YYYY-MM-DD') " +
                   ">= (DATE '2014-03-02' + TIME '00:00:00'))");
     });
 
     it('casts hstore values to float for numerical hstore searches', function () {
         assertSql({"tree.udf:awesome": {"MIN": 1}},
-                  "(( \"treemap_tree\".\"udfs\"->'awesome' )::float  >= 1)");
+                  "(( \"treemap_tree\".\"udfs\"::hstore->'awesome' )::float  >= 1)");
         assertSql({"tree.udf:awesome": {"MIN": 1.23}},
-                  "(( \"treemap_tree\".\"udfs\"->'awesome' )::float  >= 1.23)");
+                  "(( \"treemap_tree\".\"udfs\"::hstore->'awesome' )::float  >= 1.23)");
     });
 
 });

--- a/test/testMakeSql.js
+++ b/test/testMakeSql.js
@@ -199,7 +199,7 @@ describe('makeSql', function() {
                 'WHERE ( (("treemap_tree"."id" IS NOT NULL) AND ("treemap_mapfeature"."feature_type" = \'Plot\')) ) ' +
                 'AND (("treemap_tree"."diameter" >= 1 ' +
                 'AND "treemap_tree"."diameter" <= 100) ' +
-                'AND (("treemap_userdefinedcollectionvalue"."data"->\'Status\' = \'Unresolved\' ' +
+                'AND ((("treemap_userdefinedcollectionvalue"."data"::hstore->\'Status\') = \'Unresolved\' ' +
                 'AND treemap_userdefinedcollectionvalue.field_definition_id=198 ' +
                 'AND treemap_userdefinedcollectionvalue.model_id=treemap_tree.id))) ) otmfiltersql '
         });


### PR DESCRIPTION
Was: `WHERE "treemap_tree"."udfs"->'Squirrels' IS NULL`
Now: `WHERE ("treemap_tree"."udfs"::hstore->'Squirrels') IS NULL`

We've only recently been able to search for custom fields, so the tiler SQL code was never actually run; only exercised by tests which check for syntax. The syntax was just wrong, and is now corrected.

To verify, make sure the right dots show up when you search for "missing data" custom fields.