### PR TITLE
Restore support for array filter objects

### DIFF
--- a/addDefaultsToFilter.js
+++ b/addDefaultsToFilter.js
@@ -9,7 +9,11 @@ module.exports = function(filterObject, zoom, isPolygonRequest) {
 
     if (zoom >= 15 && !isPolygonRequest) {
         var defaults = {'polygonalMapFeature.polygon': {'ISNULL': true}};
-        return _.extend({}, defaults, filterObject);
+        if (_.isArray(filterObject)) {
+            return ['AND', defaults, filterObject];
+        } else {
+            return _.extend({}, defaults, filterObject);
+        }
     }
 
     return filterObject;

--- a/test/testMakeSql.js
+++ b/test/testMakeSql.js
@@ -204,4 +204,23 @@ describe('makeSql', function() {
                 'AND treemap_userdefinedcollectionvalue.model_id=treemap_tree.id))) ) otmfiltersql '
         });
     });
+
+    it('supports array syntax for non-polygon searches above zoom 14', function() {
+        assertSqlEqual({
+            zoom: 18,
+            isPolygonRequest: false,
+            displayFilter: '["Tree"]',
+            filter: '["AND",{"tree.diameter":{"MIN":1,"MAX":100}}]',
+            expected: '( SELECT DISTINCT(the_geom_webmercator) AS the_geom_webmercator, ' +
+                'feature_type FROM treemap_mapfeature LEFT OUTER JOIN ' +
+                'stormwater_polygonalmapfeature ON ' +
+                'stormwater_polygonalmapfeature.mapfeature_ptr_id = treemap_mapfeature.id ' +
+                'LEFT OUTER JOIN treemap_tree ON treemap_mapfeature.id = treemap_tree.plot_id ' +
+                'WHERE ( (("treemap_tree"."id" IS NOT NULL) ' +
+                'AND ("treemap_mapfeature"."feature_type" = \'Plot\')) ) ' +
+                'AND (("stormwater_polygonalmapfeature"."polygon" IS NULL) ' +
+                'AND (("treemap_tree"."diameter" >= 1 ' +
+                'AND "treemap_tree"."diameter" <= 100))) ) otmfiltersql '
+        });
+    });
 });


### PR DESCRIPTION
The `addDefaultsToFilter` function was assuming that the filter is always an object, but the filter grammar also supports arrays, and the currently deployed mobile apps are sending array-formatted filters.

##### Testing

On the `develop` branch, run the tiler manually to see the console output and apply a filter in one of the mobile apps. You should see `[TILE RENDER ERROR]`s appear. Checking out this branch and restarting the tiler should eliminate the errors and correctly return tiles.

---
Connects to #101 
