### PR TITLE
Exclude non-searchable boundaries from the boundaries layer

### DIFF
--- a/config.js
+++ b/config.js
@@ -69,7 +69,7 @@ module.exports = {
         }
     },
     "treeDisplayFilters": ["EmptyPlot", "Tree"],
-    "boundaryGrainstoreSql": "(SELECT the_geom_webmercator FROM treemap_boundary JOIN treemap_instance_boundaries ON treemap_instance_boundaries.boundary_id = treemap_boundary.id WHERE treemap_instance_boundaries.instance_id=<%= instanceid %>) otmfiltersql",
+    "boundaryGrainstoreSql": "(SELECT the_geom_webmercator FROM treemap_boundary JOIN treemap_instance_boundaries ON treemap_instance_boundaries.boundary_id = treemap_boundary.id WHERE treemap_instance_boundaries.instance_id=<%= instanceid %> AND treemap_boundary.searchable=true) otmfiltersql",
     "getBoundarySql" : "SELECT the_geom_webmercator FROM treemap_boundary WHERE id=<%= boundaryId %>",
     "showAtZoomSql": "(treemap_mapfeature.hide_at_zoom IS NULL OR treemap_mapfeature.hide_at_zoom < <%= zoom %>)",
     "customDbFieldNames": {


### PR DESCRIPTION
**Before:**
![screenshot 2016-05-31 at 17 07 53](https://cloud.githubusercontent.com/assets/43062/15690596/42a13b98-2752-11e6-86d4-619123985f07.png)

**After:**
![screenshot 2016-05-31 at 17 09 15](https://cloud.githubusercontent.com/assets/43062/15690630/6f9f4a22-2752-11e6-95a2-e042680010b3.png)

**Test:**

Ensure that you have the latest `otm-core` and have run migrations before testing this.

Verify that bounds do not appear at close zoom levels after marking boundaries as non-searchable.

```sql
update treemap_boundary set searchable=false;
```

Verify that boundaries appear after marking them as searchable.

```sql
update treemap_boundary set searchable=true;
```
Connects #106