### PR TITLE
Update node rollbar client

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,14 +8,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.1.0.tgz"
     },
     "rollbar": {
-      "version": "0.5.9",
+      "version": "0.6.2",
       "from": "rollbar@",
-      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-0.5.9.tgz",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-0.6.2.tgz",
       "dependencies": {
         "node-uuid": {
-          "version": "1.4.3",
+          "version": "1.4.7",
           "from": "node-uuid@1.4.x",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "lru-cache": {
           "version": "2.2.4",
@@ -31,6 +31,11 @@
           "version": "1.2.1",
           "from": "async@~1.2.1",
           "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@~2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "moment": "~2.1.0",
-    "rollbar": "^0.5.9",
+    "rollbar": "^0.6.2",
     "semver": "~1.1.0",
     "underscore": "~1.3",
     "windshaft": "0.19.4"


### PR DESCRIPTION
Upgrade node Rollbar client to `0.6.2`. 

# Testing

See [#315](https://github.com/OpenTreeMap/otm-cloud/pull/315)