### PR TITLE
Fix escaping of single quotes in filter values.

### DIFF
--- a/filterObjectToWhere.js
+++ b/filterObjectToWhere.js
@@ -119,7 +119,7 @@ function accessHStore(hStoreColumn, accessor) {
     // TODO: sql injection? why don't we call sanitize?
     var t = _.template('"<%= hStoreColumn %>"::hstore->\'<%= accessor %>\'');
     return t({hStoreColumn: hStoreColumn,
-              accessor: accessor.replace("'","''")});
+              accessor: accessor.replace(/'/g, "''")});
 }
 
 
@@ -207,7 +207,7 @@ function convertValueForIsNull(value) {
 }
 
 function convertValueForLike(value) {
-    return "'%" + utils.sanitizeSqlString(value).replace("'", "''") + "%'";
+    return "'%" + utils.sanitizeSqlString(value).replace(/'/g, "''") + "%'";
 }
 
 // `validatePredicate` throws an error if the specified `predicate` object

--- a/filterObjectUtils.js
+++ b/filterObjectUtils.js
@@ -61,7 +61,7 @@ function convertValueToEscapedSqlLiteral (value) {
     } else if (isDateTimeString(value)) {
         return dateTimeStringToSqlValue(value);
     } else {
-        return "'" + sanitizeSqlString(value).replace("'", "''") + "'";
+        return "'" + sanitizeSqlString(value).replace(/'/g, "''") + "'";
     }
 }
 

--- a/test/testFilterObjectToWhere.js
+++ b/test/testFilterObjectToWhere.js
@@ -89,6 +89,11 @@ describe('filterObjectToWhere', function() {
                   "(\"treemap_mapfeature\".\"address\" ILIKE '%Market St%')");
     });
 
+    it('escapes interior quotes in Hstore LIKE', function () {
+        assertSql({"tree.udf:Dimensions": {"LIKE": "\"8'' x 10'\""}},
+                  "((\"treemap_tree\".\"udfs\"::hstore->'Dimensions') ILIKE '%\"8'''' x 10''\"%')");
+    });
+
     // UDF MATCHES
     it('processes udf values', function() {
         assertSql({"mapFeature.udf:Clever Name": {"LIKE": "Market St"}},


### PR DESCRIPTION
We were only replacing the first `'` in each provided value, which caused
errors on values with multiple single quotes.

Connects to #104