### PR TITLE
Exit instance middleware early if query param is missing

### DIFF
--- a/http/middleware.js
+++ b/http/middleware.js
@@ -1,7 +1,14 @@
 module.exports = {
     instanceConfig: function(opts) {
         return function (req, res, next) {
-            var start = Date.now();
+            var start = Date.now(),
+                hasInstance = !!req.query.instance_id;
+            if (!hasInstance) {
+                // If we don't have an instance_id (e.g. a health-check request)
+                // skip this middleware.
+                next();
+                return;
+            }
             req.instanceConfig = {};
             opts.dbPool.connect(function(err, client, done) {
                 if (!err) {


### PR DESCRIPTION
Prior to this commit exceptions were being raised by the `instanceConfig` middleware when it ran before health check requests that do not pass an `instance_id` query parameter.

---

##### Testing

I applied this change manually on the staging instances to stop a cycle of health-check errors and terminations.

- The test steps in https://github.com/OpenTreeMap/otm-core/pull/3222 should still result in the proper dots being rendered.
- The health-check endpoint should work

```
~/Projects/otm-cloud $ vagrant ssh tiler -c "curl http://localhost/tile/health-check"
{
  "databases": [
    {
      "default": {
        "ok": true
      }
    }
  ],
  "caches": [
    {
      "default": {
        "ok": true
      }
    }
  ]
}
```

---

Connects to https://github.com/OpenTreeMap/otm-cloud/issues/421