### PR TITLE
Update tree and planting site marker colors

### DIFF
--- a/style/mapFeature.mms
+++ b/style/mapFeature.mms
@@ -1,12 +1,15 @@
 // If any changes are made to this stylesheet, make sure those
 // changes are replicated in uncoloredMapFeature.mms (if necessary)
 
-@tree_fill_color: #8BAA3D;
-@empty_plot_fill_color: #BCA371;
+@tree_fill_color: #8BAA3C;
+@tree_stroke_color: #A5BF5B;
+
+@empty_plot_fill_color: #E1C6FF;
+@empty_plot_stroke_color: #D4B5F9;
+
 @gsi_fill_color: #388E8E;
 
 @tree_gsi_border_color: #b6ce78;
-@empty_plot_border_color: #D3C3A5;
 
 #treemap_mapfeature {
     [tree_id!=null][feature_type="Plot"] {
@@ -22,9 +25,11 @@
 
     marker-allow-overlap: true;
 
-
+    [tree_id!=null][feature_type="Plot"][zoom >= 15] {
+        marker-line-color: @tree_stroke_color;
+    }
     [tree_id=null][feature_type="Plot"][zoom >= 15] {
-        marker-line-color: @empty_plot_border_color;
+        marker-line-color: @empty_plot_stroke_color;
     }
     [tree_id!=null][feature_type="Plot"][zoom >= 15] {
         marker-line-color: @tree_gsi_border_color;


### PR DESCRIPTION
## Overview

Green generally appears brown to colorblind users, so we have changed the empty planting sites to a purple-ish color.

Connects https://github.com/OpenTreeMap/otm-core/issues/3251
Depends on https://github.com/OpenTreeMap/otm-cloud/pull/467

### Demo

<img width="801" alt="screen shot 2018-12-21 at 3 21 22 pm" src="https://user-images.githubusercontent.com/17363/50366004-6dcb7780-0534-11e9-80b4-7be1dc45c545.png">

<img width="800" alt="screen shot 2018-12-21 at 3 24 38 pm" src="https://user-images.githubusercontent.com/17363/50366025-8e93cd00-0534-11e9-98cd-ccdcbe83a48c.png">

## Testing Instructions

 * Run `./scripts/debugtiler.sh` to ensure the new styles are loaded.
 * Browse an instance with both trees and planting sites and verify that empty planting sites now appear purplish.