### PR TITLE
Update moment to 2.19.3

### DIFF
--- a/filterObjectUtils.js
+++ b/filterObjectUtils.js
@@ -8,20 +8,28 @@ var config = require('./config');
 // and format date and datetime strings.
 var DATETIME_FORMATS = {
     full: 'YYYY-MM-DD HH:mm:ss',
+    fullWithT: 'YYYY-MM-DDTHH:mm:ss',
     date: 'YYYY-MM-DD',
     time: 'HH:mm:ss'
 };
 
+// We always want to use strict mode for our date parsing. Defining a boolean
+// constant makes the moment constructor calls more self documenting.
+var STRICT = true;
+
 // `isDateString` returns a boolean indicating whether or not the string value
 // should be treated as datetime.
 function isDateTimeString(value) {
-    return moment(value, DATETIME_FORMATS.full).isValid();
+    return moment(value, DATETIME_FORMATS.full, STRICT).isValid() ||
+        moment(value, DATETIME_FORMATS.fullWithT, STRICT).isValid();
 }
 
 // `dateTimeStringToSqlValue` converts a datetime string into a Postgres
 // compatible literal date and time value.
 function dateTimeStringToSqlValue(dtString) {
-    var m = moment(dtString, DATETIME_FORMATS.full);
+    var m = moment(dtString, DATETIME_FORMATS.full, STRICT).isValid() ?
+        moment(dtString, DATETIME_FORMATS.full, STRICT) :
+        moment(dtString, DATETIME_FORMATS.fullWithT, STRICT);
     return "(DATE '" + m.format(DATETIME_FORMATS.date) +
         "' + TIME '" + m.format(DATETIME_FORMATS.time) + "')";
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "express": "3.21.2",
-    "moment": "2.1.0",
+    "moment": "2.19.3",
     "rollbar": "^2.2.7",
     "underscore": "^1.8.3",
     "windshaft": "^3.3.1"


### PR DESCRIPTION
## Overview

Incorporates bug fixes.

The newer version of moment has a more relaxed default mode which was accepting things like "1234 market st" as a valid date because it started with a 4 digit number. Using strict mode resolves the issue, but requires the introduction of a new format to correctly cover the two supported datetime representations.

Connects #121
Depends on https://github.com/OpenTreeMap/otm-cloud/pull/467

## Testing Instructions

 * Verify that the tests pass
   * `vagrant ssh tiler -c "cd /opt/tiler && envdir /etc/otm.d/env make lint"`
   * `vagrant ssh tiler -c "cd /opt/tiler && envdir /etc/otm.d/env make test"`
* Create an instance.
* Add a few trees with different "Date Planted" dates and verify that advanced searching on that date field returns the correct map dots.