### PR TITLE
Make grainstore database name configuration explicit

### DIFF
--- a/server.js
+++ b/server.js
@@ -73,7 +73,8 @@ var windshaftConfig = {
             user: process.env.OTM_DB_USER || 'otm',
             password: process.env.OTM_DB_PASSWORD || 'otm',
             host: process.env.OTM_DB_HOST || 'localhost',
-            port: process.env.OTM_DB_PORT || 5432
+            port: process.env.OTM_DB_PORT || 5432,
+            dbname: dbname
         }
     }, // See grainstore npm for other options
 


### PR DESCRIPTION
The health check for this service attempts to retrieve the `dbname` attribute from the `grainstore` configuration:

https://github.com/OpenTreeMap/otm-tiler/blob/514cd776bdaeb098b4885055c7337d70733986ff/healthCheck.js#L95-L107

The values retrieved from that configuration object are then fed to the `checkPostgres` function:

https://github.com/OpenTreeMap/otm-tiler/blob/514cd776bdaeb098b4885055c7337d70733986ff/healthCheck.js#L111-L113

Which is used to build a connection string for connecting to the database:

https://github.com/OpenTreeMap/otm-tiler/blob/514cd776bdaeb098b4885055c7337d70733986ff/healthCheck.js#L23-L31

When `dbname` is missing from the `grainstore` configuration object, the connection string omits a database name to connect to:

```
postgres://username:password@dbhost/

vs.

postgres://username:password@dbhost/dbname
```

This leads to a client default of using the username of the UNIX user that initiated the connection attempt. Instead of using that default, these changes make sure that `dbname` is used.

---

**Testing**

Please use https://github.com/OpenTreeMap/otm-cloud/pull/491 to review this PR.